### PR TITLE
Fix getzelnodecount to be more accurate

### DIFF
--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -1571,11 +1571,14 @@ UniValue getzelnodecount (const UniValue& params, bool fHelp)
 
     if (IsDZelnodeActive())
     {
-        int nCUMULUS = g_zelnodeCache.mapZelnodeList.at(CUMULUS).listConfirmedZelnodes.size();
-        int nNIMBUS = g_zelnodeCache.mapZelnodeList.at(NIMBUS).listConfirmedZelnodes.size();
-        int nSTRATUS = g_zelnodeCache.mapZelnodeList.at(STRATUS).listConfirmedZelnodes.size();
+        int ipv4 = 0, ipv6 = 0, onion = 0, nTotal = 0, nCUMULUS = 0, nNIMBUS = 0, nSTRATUS = 0;
+        {
+            LOCK(g_zelnodeCache.cs);
 
-        int nTotal = g_zelnodeCache.mapConfirmedZelnodeData.size();
+            g_zelnodeCache.CountNetworks(ipv4, ipv6, onion, nCUMULUS, nNIMBUS, nSTRATUS);
+
+            nTotal = g_zelnodeCache.mapConfirmedZelnodeData.size();
+        }
 
         obj.push_back(Pair("total", nTotal));
         obj.push_back(Pair("stable", nTotal));
@@ -1585,9 +1588,6 @@ UniValue getzelnodecount (const UniValue& params, bool fHelp)
         obj.push_back(Pair("cumulus-enabled", nCUMULUS));
         obj.push_back(Pair("nimbus-enabled", nNIMBUS));
         obj.push_back(Pair("stratus-enabled", nSTRATUS));
-
-        int ipv4 = 0, ipv6 = 0, onion = 0;
-        g_zelnodeCache.CountNetworks(ipv4, ipv6, onion);
 
         obj.push_back(Pair("ipv4", ipv4));
         obj.push_back(Pair("ipv6", ipv6));

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -1934,8 +1934,8 @@ std::string ZelnodeLocationToString(int nLocation) {
     }
 }
 
-void ZelnodeCache::CountNetworks(int& ipv4, int& ipv6, int& onion) {
-    for (auto &entry : mapConfirmedZelnodeData) {
+void ZelnodeCache::CountNetworks(int& ipv4, int& ipv6, int& onion, int& nCUMULUS, int& nNIMBUS, int& nStratus) {
+    for (const auto& entry : mapConfirmedZelnodeData) {
         std::string strHost = entry.second.ip;
         CNetAddr node = CNetAddr(strHost, false);
         int nNetwork = node.GetNetwork();
@@ -1949,6 +1949,15 @@ void ZelnodeCache::CountNetworks(int& ipv4, int& ipv6, int& onion) {
             case 3 :
                 onion++;
                 break;
+        }
+
+        // Gather which location they are in
+        if (mapZelnodeList.at(CUMULUS).setConfirmedTxInList.count(entry.first)) {
+            nNIMBUS++;
+        } else if (mapZelnodeList.at(NIMBUS).setConfirmedTxInList.count(entry.first)) {
+            nCUMULUS++;
+        } else if (mapZelnodeList.at(STRATUS).setConfirmedTxInList.count(entry.first)) {
+            nStratus++;
         }
     }
 }

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -721,7 +721,7 @@ public:
 
     void DumpZelnodeCache();
 
-    void CountNetworks(int& ipv4, int& ipv6, int& onion);
+    void CountNetworks(int& ipv4, int& ipv6, int& onion, int& nCUMULUS, int& nNIMBUS, int& nStratus);
 };
 
 int GetZelnodeExpirationCount(const int& p_nHeight);


### PR DESCRIPTION
- The **mapZelnodeList** contains confirmed and expired flux nodes, and shouldn't be used for accurate counts.
- Instead, we should only use the **mapConfirmedZelnodes** for accurate counts. 
- Updated **getzelnodecount** to also return accurate counts based on the zelnode Tier. 