### PR TITLE
Fix mempool, clean code, stop dosing peers

### DIFF
--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -701,7 +701,7 @@ public:
     void CheckForUndoExpiredStartTx(const int& p_nHeight);
     bool CheckIfStarted(const COutPoint& out);
     bool CheckIfConfirmed(const COutPoint& out);
-    bool CheckUpdateHeight(const CTransaction& p_transaction, const ZelnodeCacheData& data, const int p_nHeight = 0);
+    bool CheckUpdateHeight(const CTransaction& p_transaction, const int p_nHeight = 0);
 
     bool CheckZelnodePayout(const CTransaction& coinbase, const int p_Height, ZelnodeCache* p_zelnodeCache = nullptr);
 
@@ -722,6 +722,8 @@ public:
     void DumpZelnodeCache();
 
     void CountNetworks(int& ipv4, int& ipv6, int& onion);
+
+    bool CheckConfirmationHeights(const int nHeight, const COutPoint& out, const std::string& ip);
 };
 
 int GetZelnodeExpirationCount(const int& p_nHeight);


### PR DESCRIPTION
- Peers are sending transaction they think are valid, if this is a confirmation transaction that just got mined, we fail to accept it and DOS them. Instead, we do a check before we confirm the transaction it valid to see if it meets confirmation window. If not, we drop the transaction network message and move on
- Added ability for Zelnode transactions to override other transaction in the mempool if they have a newer sigTime in the transaction. Should help stuck transactions in the mempools that aren't being mined
- Cleaned up some code in zelnode.cpp, and move it to a function so it can be used in AcceptToMemoryPool, and ContextualCheckTransaction