### PR TITLE
[NOT NEEDED] Witness rework (From Zero)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -208,6 +208,7 @@ BITCOIN_CORE_H = \
   wallet/asyncrpcoperation_common.h \
   wallet/asyncrpcoperation_mergetoaddress.h \
   wallet/asyncrpcoperation_saplingmigration.h \
+	wallet/asyncrpcoperation_saplingconsolidation.h \
   wallet/asyncrpcoperation_sendmany.h \
   wallet/asyncrpcoperation_shieldcoinbase.h \
   wallet/crypter.h \
@@ -325,6 +326,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/asyncrpcoperation_common.cpp \
   wallet/asyncrpcoperation_mergetoaddress.cpp \
   wallet/asyncrpcoperation_saplingmigration.cpp \
+	wallet/asyncrpcoperation_saplingconsolidation.cpp \
   wallet/asyncrpcoperation_sendmany.cpp \
   wallet/asyncrpcoperation_shieldcoinbase.cpp \
   wallet/crypter.cpp \

--- a/src/gtest/test_mempoollimit.cpp
+++ b/src/gtest/test_mempoollimit.cpp
@@ -121,7 +121,7 @@ TEST(MempoolLimitTests, WeightedTxInfoFromTx)
 
     // Default fee
     {
-        auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+        auto builder = TransactionBuilder(consensusParams, 1);
         builder.AddSaplingSpend(sk.expanded_spending_key(), testNote.note, testNote.tree.root(), testNote.tree.witness());
         builder.AddSaplingOutput(sk.full_viewing_key().ovk, sk.default_address(), 25000, {});
         
@@ -132,7 +132,7 @@ TEST(MempoolLimitTests, WeightedTxInfoFromTx)
     
     // Lower than standard fee
     {
-        auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+        auto builder = TransactionBuilder(consensusParams, 1);
         builder.AddSaplingSpend(sk.expanded_spending_key(), testNote.note, testNote.tree.root(), testNote.tree.witness());
         builder.AddSaplingOutput(sk.full_viewing_key().ovk, sk.default_address(), 25000, {});
         builder.SetFee(9999);
@@ -144,7 +144,7 @@ TEST(MempoolLimitTests, WeightedTxInfoFromTx)
 
     // Larger Tx
     {
-        auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+        auto builder = TransactionBuilder(consensusParams, 1);
         builder.AddSaplingSpend(sk.expanded_spending_key(), testNote.note, testNote.tree.root(), testNote.tree.witness());
         builder.AddSaplingOutput(sk.full_viewing_key().ovk, sk.default_address(), 5000, {});
         builder.AddSaplingOutput(sk.full_viewing_key().ovk, sk.default_address(), 5000, {});

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -421,6 +421,10 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), 100));
     strUsage += HelpMessageOpt("-migration", _("Enable the Sprout to Sapling migration"));
     strUsage += HelpMessageOpt("-migrationdestaddress=<zaddr>", _("Set the Sapling migration address"));
+    strUsage += HelpMessageOpt("-deletetx", _("Enable Old Transaction Deletion"));
+    strUsage += HelpMessageOpt("-deleteinterval", strprintf(_("Delete transaction every <n> blocks during inital block download (default: %i)"), DEFAULT_TX_DELETE_INTERVAL));
+    strUsage += HelpMessageOpt("-keeptxnum", strprintf(_("Keep the last <n> transactions (default: %i)"), DEFAULT_TX_RETENTION_LASTTX));
+    strUsage += HelpMessageOpt("-keeptxfornblocks", strprintf(_("Keep transactions for at least <n> blocks (default: %i)"), DEFAULT_TX_RETENTION_BLOCKS));
     if (showDebug)
         strUsage += HelpMessageOpt("-mintxfee=<amt>", strprintf("Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)",
             CURRENCY_UNIT, FormatMoney(CWallet::minTxFee.GetFeePerK())));
@@ -471,7 +475,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf("Stop running after importing blocks from disk (default: %u)", 0));
         strUsage += HelpMessageOpt("-nuparams=hexBranchId:activationHeight", "Use given activation height for specified network upgrade (regtest-only)");
     }
-    string debugCategories = "addrman, alert, bench, coindb, db, estimatefee, http, libevent, lock, mempool, net, partitioncheck, pow, proxy, prune, "
+    string debugCategories = "addrman, alert, bench, coindb, db, deletetx, estimatefee, http, libevent, lock, mempool, net, partitioncheck, pow, proxy, prune, "
                              "rand, reindex, rpc, selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc)"; // Don't translate these
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied or if <category> = 1, output all debugging information.") + " " + _("<category> can be:") + " " + debugCategories + ".");
@@ -1730,6 +1734,27 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             if (GetArg("-migrationdestaddress", "").empty()) {
                 strErrors << _("Error if -migration is set, -migrationdestaddress must also be set to a valid sapling address") << "\n";
             }
+        }
+
+        //Set Transaction Deletion Options
+        fTxDeleteEnabled = GetBoolArg("-deletetx", false);
+        fTxConflictDeleteEnabled = GetBoolArg("-deleteconflicttx", true);
+
+        fDeleteInterval = GetArg("-deleteinterval", DEFAULT_TX_DELETE_INTERVAL);
+        if (fDeleteInterval < 1)
+          return InitError("deleteinterval must be greater than 0");
+
+        fKeepLastNTransactions = GetArg("-keeptxnum", DEFAULT_TX_RETENTION_LASTTX);
+        if (fKeepLastNTransactions < 1)
+          return InitError("keeptxnum must be greater than 0");
+
+        fDeleteTransactionsAfterNBlocks = GetArg("-keeptxfornblocks", DEFAULT_TX_RETENTION_BLOCKS);
+        if (fDeleteTransactionsAfterNBlocks < 1)
+          return InitError("keeptxfornblocks must be greater than 0");
+
+        if (fDeleteTransactionsAfterNBlocks < MAX_REORG_LENGTH + 1 ) {
+          LogPrintf("keeptxfornblock is less the MAX_REORG_LENGTH, Setting to %i\n", MAX_REORG_LENGTH + 1);
+          fDeleteTransactionsAfterNBlocks = MAX_REORG_LENGTH + 1;
         }
 
         if (fFirstRun)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -918,6 +918,7 @@ bool ContextualCheckTransaction(
         const int nHeight,
         const int dosLevel,
         bool fFromAccept,
+        bool fFromMempool,
         bool (*isInitBlockDownload)(const CChainParams&))
 {
     bool saplingActive = NetworkUpgradeActive(nHeight, chainparams.GetConsensus(), Consensus::UPGRADE_ACADIA);
@@ -1242,7 +1243,7 @@ bool ContextualCheckTransaction(
 
                 // Check the update height, but make sure we only pass in the height if this check is coming from an AcceptBlock call
                 // If it is coming from an AcceptBlock call pass in the height of the block otherwise use the default 0
-                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx, fFromAccept ? nHeight : 0)) {
+                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx, fFromAccept || fFromMempool ? nHeight : 0)) {
                     fFailure = true;
                     strFailMessage = "zelnode-tx-invalid-update-confirm-outpoint-not-confirmed-or-too-soon";
                 }
@@ -1648,7 +1649,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
     // DoS level set to 10 to be more forgiving.
     // Check transaction contextually against the set of consensus rules which apply in the next block to be mined.
-    if (!ContextualCheckTransaction(tx, state, Params(), nextBlockHeight, 10, false)) {
+    if (!ContextualCheckTransaction(tx, state, Params(), nextBlockHeight, 10, false, true)) {
         return error("AcceptToMemoryPool: ContextualCheckTransaction failed");
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1635,7 +1635,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         if (tx.nType == ZELNODE_CONFIRM_TX_TYPE && tx.nUpdateType == ZelnodeUpdateType::UPDATE_CONFIRM) {
             {
                 LOCK(g_zelnodeCache.cs);
-                if (!g_zelnodeCache.CheckConfirmationHeights(nextBlockHeight - 1, tx.collateralOut, tx.ip)) {
+                if (!g_zelnodeCache.CheckConfirmationHeights(nextBlockHeight, tx.collateralOut, tx.ip)) {
                     LogPrint("mempool", "Dropping confirmation zelnode txid %s : failed CheckConfirmationHeights check\n", tx.GetHash().ToString());
                     return false;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1240,7 +1240,9 @@ bool ContextualCheckTransaction(
                     strFailMessage = "zelnode-tx-invalid-update-confirm-outpoint-not-confirmed";
                 }
 
-                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx)) {
+                // Check the update height, but make sure we only pass in the height if this check is coming from an AcceptBlock call
+                // If it is coming from an AcceptBlock call pass in the height of the block otherwise use the default 0
+                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx, fFromAccept ? nHeight : 0)) {
                     fFailure = true;
                     strFailMessage = "zelnode-tx-invalid-update-confirm-outpoint-not-confirmed-or-too-soon";
                 }
@@ -1633,7 +1635,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             {
                 LOCK(g_zelnodeCache.cs);
                 if (!g_zelnodeCache.CheckConfirmationHeights(nextBlockHeight - 1, tx.collateralOut, tx.ip)) {
-                    LogPrint("mempool", "Dropping confirmation zelnode txid %s : failed CheckConfirmationHeights check", tx.GetHash().ToString());
+                    LogPrint("mempool", "Dropping confirmation zelnode txid %s : failed CheckConfirmationHeights check\n", tx.GetHash().ToString());
                     return false;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5583,7 +5583,7 @@ bool LoadBlockIndex()
     return true;
 }
 
-bool InitBlockIndex(const CChainParams& chainparams) 
+bool InitBlockIndex(const CChainParams& chainparams)
 {
     LOCK(cs_main);
 

--- a/src/main.h
+++ b/src/main.h
@@ -204,11 +204,11 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
-/** 
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
- * 
+ *
  * @param[out]  state   This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state if pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface (see validationinterface.h) - this will have its BlockChecked method called whenever *any* block completes validation.
  * @param[in]   pfrom   The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
  * @param[in]   pblock  The block we want to process.
@@ -311,7 +311,7 @@ CAmount GetMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowF
 /**
  * Check transaction inputs, and make sure any
  * pay-to-script-hash transactions are evaluating IsStandard scripts
- * 
+ *
  * Why bother? To avoid denial-of-service attacks; an attacker
  * can submit a standard HASH... OP_EQUAL transaction,
  * which will get accepted into blocks. The redemption
@@ -320,14 +320,14 @@ CAmount GetMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowF
  *   DUP CHECKSIG DROP ... repeated 100 times... OP_1
  */
 
-/** 
+/**
  * Check for standard transaction types
  * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
  * @return True if all inputs (scriptSigs) use only standard transaction forms
  */
 bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, uint32_t consensusBranchId);
 
-/** 
+/**
  * Count ECDSA signature operations the old-fashioned (pre-0.6) way
  * @return number of sigops this transaction's outputs will produce when spent
  * @see CTransaction::FetchInputs
@@ -336,7 +336,7 @@ unsigned int GetLegacySigOpCount(const CTransaction& tx);
 
 /**
  * Count ECDSA signature operations in pay-to-script-hash inputs.
- * 
+ *
  * @param[in] mapInputs Map of previous transactions that have outputs we're spending
  * @return maximum number of sigops required to validate this transaction's inputs
  * @see CTransaction::FetchInputs
@@ -411,9 +411,9 @@ bool IsExpiringSoonTx(const CTransaction &tx, int nNextBlockHeight);
  */
 bool CheckFinalTx(const CTransaction &tx, int flags = -1);
 
-/** 
+/**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {

--- a/src/main.h
+++ b/src/main.h
@@ -357,6 +357,7 @@ bool ContextualCheckInputs(const CTransaction& tx, CValidationState &state, cons
 /** Check a transaction contextually against a set of consensus rules */
 bool ContextualCheckTransaction(const CTransaction& tx, CValidationState &state,
                                 const CChainParams& chainparams, int nHeight, int dosLevel, bool fFromAccept,
+                                bool fFromMempool = false,
                                 bool (*isInitBlockDownload)(const CChainParams&) = IsInitialBlockDownload);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -50,6 +50,7 @@ enum RPCErrorCode
     RPC_VERIFY_REJECTED             = -26, //! Transaction or block was rejected by network rules
     RPC_VERIFY_ALREADY_IN_CHAIN     = -27, //! Transaction already in chain
     RPC_IN_WARMUP                   = -28, //! Client still warming up
+    RPC_DISABLED_BEFORE_WITNESSES   = -31, //! Disable before Note Witnesses have been built
 
     //! Aliases for backward compatibility
     RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -32,6 +32,7 @@
 using namespace RPCServer;
 using namespace std;
 
+bool initWitnessesBuilt = false;
 static bool fRPCRunning = false;
 static bool fRPCInWarmup = true;
 static std::string rpcWarmupStatus("RPC server started");
@@ -443,6 +444,9 @@ UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params
     const CRPCCommand *pcmd = tableRPC[strMethod];
     if (!pcmd)
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found");
+
+    if (!initWitnessesBuilt && pcmd->name == "z_sendmany")
+        throw JSONRPCError(RPC_DISABLED_BEFORE_WITNESSES, "RPC Command disabled until witnesses are built.");
 
     g_rpcSignals.PreCommand(*pcmd);
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -20,6 +20,8 @@
 
 #include <univalue.h>
 
+extern bool initWitnessesBuilt;
+
 class AsyncRPCQueue;
 class CRPCCommand;
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1288,7 +1288,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_taddr_to_sapling)
     pwalletMain->AddToWallet(wtx, true, NULL);
 
     // Context that z_sendmany requires
-    auto builder = TransactionBuilder(consensusParams, nextBlockHeight, expiryDelta, pwalletMain);
+    auto builder = TransactionBuilder(consensusParams, nextBlockHeight, pwalletMain);
     mtx = CreateNewContextualCMutableTransaction(consensusParams, nextBlockHeight);
 
     std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, 1 * COIN, "ABCD") };

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -50,7 +50,6 @@ std::string TransactionBuilderResult::GetError() {
 TransactionBuilder::TransactionBuilder(
     const Consensus::Params& consensusParams,
     int nHeight,
-    int nExpiryDelta,
     CKeyStore* keystore,
     ZCJoinSplit* sproutParams,
     CCoinsViewCache* coinsView,
@@ -62,7 +61,7 @@ TransactionBuilder::TransactionBuilder(
     coinsView(coinsView),
     cs_coinsView(cs_coinsView)
 {
-    mtx = CreateNewContextualCMutableTransaction(consensusParams, nHeight, nExpiryDelta);
+    mtx = CreateNewContextualCMutableTransaction(consensusParams, nHeight);
 }
 
 // This exception is thrown in certain scenarios when building JoinSplits fails.
@@ -75,6 +74,14 @@ struct JSDescException : public std::exception
 private:
     std::string msg;
 };
+
+void TransactionBuilder::SetExpiryHeight(uint32_t nExpiryHeight)
+{
+    if (nExpiryHeight < nHeight || nExpiryHeight <= 0 || nExpiryHeight >= TX_EXPIRY_HEIGHT_THRESHOLD) {
+        throw new std::runtime_error("TransactionBuilder::SetExpiryHeight: invalid expiry height");
+    }
+    mtx.nExpiryHeight = nExpiryHeight;
+}
 
 void TransactionBuilder::AddSaplingSpend(
     libzelcash::SaplingExpandedSpendingKey expsk,

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -95,11 +95,12 @@ public:
     TransactionBuilder(
         const Consensus::Params& consensusParams,
         int nHeight,
-        int nExpiryDelta,
         CKeyStore* keyStore = nullptr,
         ZCJoinSplit* sproutParams = nullptr,
         CCoinsViewCache* coinsView = nullptr,
         CCriticalSection* cs_coinsView = nullptr);
+
+    void SetExpiryHeight(uint32_t nExpiryHeight);
 
     void SetFee(CAmount fee);
 

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -244,7 +244,7 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
     auto fvk = sk.expsk.full_viewing_key();
     auto pa = sk.DefaultAddress();
 
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta, &keyStore);
+    auto builder = TransactionBuilder(consensusParams, 1, &keyStore);
     builder.SetFee(0);
     builder.AddTransparentInput(COutPoint(), scriptPubKey, value);
     builder.AddSaplingOutput(fvk.ovk, pa, value, {});

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
@@ -1,0 +1,214 @@
+#include "assert.h"
+#include "boost/variant/static_visitor.hpp"
+#include "asyncrpcoperation_saplingconsolidation.h"
+#include "init.h"
+#include "key_io.h"
+#include "rpc/protocol.h"
+#include "random.h"
+#include "sync.h"
+#include "tinyformat.h"
+#include "transaction_builder.h"
+#include "util.h"
+#include "utilmoneystr.h"
+#include "wallet.h"
+
+CAmount fConsolidationTxFee = DEFAULT_CONSOLIDATION_FEE;
+bool fConsolidationMapUsed = false;
+const int CONSOLIDATION_EXPIRY_DELTA = 15;
+
+
+AsyncRPCOperation_saplingconsolidation::AsyncRPCOperation_saplingconsolidation(int targetHeight) : targetHeight_(targetHeight) {}
+
+AsyncRPCOperation_saplingconsolidation::~AsyncRPCOperation_saplingconsolidation() {}
+
+void AsyncRPCOperation_saplingconsolidation::main() {
+    if (isCancelled())
+        return;
+
+    set_state(OperationStatus::EXECUTING);
+    start_execution_clock();
+
+    bool success = false;
+
+    try {
+        success = main_impl();
+    } catch (const UniValue& objError) {
+        int code = find_value(objError, "code").get_int();
+        std::string message = find_value(objError, "message").get_str();
+        set_error_code(code);
+        set_error_message(message);
+    } catch (const runtime_error& e) {
+        set_error_code(-1);
+        set_error_message("runtime error: " + string(e.what()));
+    } catch (const logic_error& e) {
+        set_error_code(-1);
+        set_error_message("logic error: " + string(e.what()));
+    } catch (const exception& e) {
+        set_error_code(-1);
+        set_error_message("general exception: " + string(e.what()));
+    } catch (...) {
+        set_error_code(-2);
+        set_error_message("unknown error");
+    }
+
+    stop_execution_clock();
+
+    if (success) {
+        set_state(OperationStatus::SUCCESS);
+    } else {
+        set_state(OperationStatus::FAILED);
+    }
+
+    std::string s = strprintf("%s: Sapling Consolidation transaction created. (status=%s", getId(), getStateAsString());
+    if (success) {
+        s += strprintf(", success)\n");
+    } else {
+        s += strprintf(", error=%s)\n", getErrorMessage());
+    }
+
+    LogPrintf("%s", s);
+}
+
+bool AsyncRPCOperation_saplingconsolidation::main_impl() {
+    LogPrint("zrpcunsafe", "%s: Beginning AsyncRPCOperation_saplingconsolidation.\n", getId());
+    auto consensusParams = Params().GetConsensus();
+    auto nextActivationHeight = NextActivationHeight(targetHeight_, consensusParams);
+    if (nextActivationHeight && targetHeight_ + CONSOLIDATION_EXPIRY_DELTA >= nextActivationHeight.get()) {
+        LogPrint("zrpcunsafe", "%s: Consolidation txs would be created before a NU activation but may expire after. Skipping this round.\n", getId());
+        setConsolidationResult(0, 0, std::vector<std::string>());
+        return true;
+    }
+
+    std::vector<SproutNoteEntry> sproutEntries;
+    std::vector<SaplingNoteEntry> saplingEntries;
+    std::set<libzcash::SaplingPaymentAddress> addresses;
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        // We set minDepth to 11 to avoid unconfirmed notes and in anticipation of specifying
+        // an anchor at height N-10 for each Sprout JoinSplit description
+        // Consider, should notes be sorted?
+        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, "", 11);
+        if (fConsolidationMapUsed) {
+            const vector<string>& v = mapMultiArgs["-consolidatesaplingaddress"];
+            for(int i = 0; i < v.size(); i++) {
+                auto zAddress = DecodePaymentAddress(v[i]);
+                if (boost::get<libzcash::SaplingPaymentAddress>(&zAddress) != nullptr) {
+                    libzcash::SaplingPaymentAddress saplingAddress = boost::get<libzcash::SaplingPaymentAddress>(zAddress);
+                    addresses.insert(saplingAddress );
+                }
+            }
+        } else {
+            pwalletMain->GetSaplingPaymentAddresses(addresses);
+        }
+    }
+
+    int numTxCreated = 0;
+    std::vector<std::string> consolidationTxIds;
+    CAmount amountConsolidated = 0;
+    CCoinsViewCache coinsView(pcoinsTip);
+
+    for (auto addr : addresses) {
+        libzcash::SaplingExtendedSpendingKey extsk;
+        if (pwalletMain->GetSaplingExtendedSpendingKey(addr, extsk)) {
+
+            std::vector<SaplingNoteEntry> fromNotes;
+            CAmount amountToSend = 0;
+            int maxQuantity = rand() % 35 + 10;
+            for (const SaplingNoteEntry& saplingEntry : saplingEntries) {
+
+                libzcash::SaplingIncomingViewingKey ivk;
+                pwalletMain->GetSaplingIncomingViewingKey(boost::get<libzcash::SaplingPaymentAddress>(saplingEntry.address), ivk);
+
+                //Select Notes from that same address we will be sending to.
+                if (ivk == extsk.expsk.full_viewing_key().in_viewing_key()) {
+                  amountToSend += CAmount(saplingEntry.note.value());
+                  fromNotes.push_back(saplingEntry);
+                }
+
+                //Only use a randomly determined number of notes between 10 and 45
+                if (fromNotes.size() >= maxQuantity)
+                  break;
+
+            }
+
+            //random minimum 2 - 12 required
+            int minQuantity = rand() % 10 + 2;
+            if (fromNotes.size() < minQuantity)
+              continue;
+
+            amountConsolidated += amountToSend;
+            auto builder = TransactionBuilder(consensusParams, targetHeight_, pwalletMain, pzcashParams, &coinsView, &cs_main);
+            builder.SetExpiryHeight(targetHeight_ + CONSOLIDATION_EXPIRY_DELTA);
+            LogPrint("zrpcunsafe", "%s: Beginning creating transaction with Sapling output amount=%s\n", getId(), FormatMoney(amountToSend - fConsolidationTxFee));
+
+            // Select Sapling notes
+            std::vector<SaplingOutPoint> ops;
+            std::vector<libzcash::SaplingNote> notes;
+            for (auto fromNote : fromNotes) {
+                ops.push_back(fromNote.op);
+                notes.push_back(fromNote.note);
+            }
+
+            // Fetch Sapling anchor and witnesses
+            uint256 anchor;
+            std::vector<boost::optional<SaplingWitness>> witnesses;
+            {
+                LOCK2(cs_main, pwalletMain->cs_wallet);
+                pwalletMain->GetSaplingNoteWitnesses(ops, witnesses, anchor);
+            }
+
+            // Add Sapling spends
+            for (size_t i = 0; i < notes.size(); i++) {
+                if (!witnesses[i]) {
+                    LogPrint("zrpcunsafe", "%s: Missing Witnesses. Stopping.\n", getId());
+                    break;
+                }
+                builder.AddSaplingSpend(extsk.expsk, notes[i], anchor, witnesses[i].get());
+            }
+
+            builder.SetFee(fConsolidationTxFee);
+            builder.AddSaplingOutput(extsk.expsk.ovk, addr, amountToSend - fConsolidationTxFee);
+            CTransaction tx = builder.Build().GetTxOrThrow();
+
+            if (isCancelled()) {
+                LogPrint("zrpcunsafe", "%s: Canceled. Stopping.\n", getId());
+                break;
+            }
+
+            pwalletMain->CommitConsolidationTx(tx);
+            LogPrint("zrpcunsafe", "%s: Committed consolidation transaction with txid=%s\n", getId(), tx.GetHash().ToString());
+            amountConsolidated += amountToSend - fConsolidationTxFee;
+            consolidationTxIds.push_back(tx.GetHash().ToString());
+
+        }
+    }
+
+    LogPrint("zrpcunsafe", "%s: Created %d transactions with total Sapling output amount=%s\n", getId(), numTxCreated, FormatMoney(amountConsolidated));
+    setConsolidationResult(numTxCreated, amountConsolidated, consolidationTxIds);
+    return true;
+
+}
+
+void AsyncRPCOperation_saplingconsolidation::setConsolidationResult(int numTxCreated, const CAmount& amountConsolidated, const std::vector<std::string>& consolidationTxIds) {
+    UniValue res(UniValue::VOBJ);
+    res.push_back(Pair("num_tx_created", numTxCreated));
+    res.push_back(Pair("amount_consolidated", FormatMoney(amountConsolidated)));
+    UniValue txIds(UniValue::VARR);
+    for (const std::string& txId : consolidationTxIds) {
+        txIds.push_back(txId);
+    }
+    res.push_back(Pair("consolidation_txids", txIds));
+    set_result(res);
+}
+
+void AsyncRPCOperation_saplingconsolidation::cancel() {
+    set_state(OperationStatus::CANCELLED);
+}
+
+UniValue AsyncRPCOperation_saplingconsolidation::getStatus() const {
+    UniValue v = AsyncRPCOperation::getStatus();
+    UniValue obj = v.get_obj();
+    obj.push_back(Pair("method", "saplingconsolidation"));
+    obj.push_back(Pair("target_height", targetHeight_));
+    return obj;
+}

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
@@ -81,7 +81,7 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
 
     std::vector<SproutNoteEntry> sproutEntries;
     std::vector<SaplingNoteEntry> saplingEntries;
-    std::set<libzcash::SaplingPaymentAddress> addresses;
+    std::set<libzelcash::SaplingPaymentAddress> addresses;
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
         // We set minDepth to 11 to avoid unconfirmed notes and in anticipation of specifying
@@ -92,8 +92,8 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
             const vector<string>& v = mapMultiArgs["-consolidatesaplingaddress"];
             for(int i = 0; i < v.size(); i++) {
                 auto zAddress = DecodePaymentAddress(v[i]);
-                if (boost::get<libzcash::SaplingPaymentAddress>(&zAddress) != nullptr) {
-                    libzcash::SaplingPaymentAddress saplingAddress = boost::get<libzcash::SaplingPaymentAddress>(zAddress);
+                if (boost::get<libzelcash::SaplingPaymentAddress>(&zAddress) != nullptr) {
+                    libzelcash::SaplingPaymentAddress saplingAddress = boost::get<libzelcash::SaplingPaymentAddress>(zAddress);
                     addresses.insert(saplingAddress );
                 }
             }
@@ -108,7 +108,7 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
     CCoinsViewCache coinsView(pcoinsTip);
 
     for (auto addr : addresses) {
-        libzcash::SaplingExtendedSpendingKey extsk;
+        libzelcash::SaplingExtendedSpendingKey extsk;
         if (pwalletMain->GetSaplingExtendedSpendingKey(addr, extsk)) {
 
             std::vector<SaplingNoteEntry> fromNotes;
@@ -116,8 +116,8 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
             int maxQuantity = rand() % 35 + 10;
             for (const SaplingNoteEntry& saplingEntry : saplingEntries) {
 
-                libzcash::SaplingIncomingViewingKey ivk;
-                pwalletMain->GetSaplingIncomingViewingKey(boost::get<libzcash::SaplingPaymentAddress>(saplingEntry.address), ivk);
+                libzelcash::SaplingIncomingViewingKey ivk;
+                pwalletMain->GetSaplingIncomingViewingKey(boost::get<libzelcash::SaplingPaymentAddress>(saplingEntry.address), ivk);
 
                 //Select Notes from that same address we will be sending to.
                 if (ivk == extsk.expsk.full_viewing_key().in_viewing_key()) {
@@ -137,13 +137,13 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
               continue;
 
             amountConsolidated += amountToSend;
-            auto builder = TransactionBuilder(consensusParams, targetHeight_, pwalletMain, pzcashParams, &coinsView, &cs_main);
+            auto builder = TransactionBuilder(consensusParams, targetHeight_, pwalletMain, pzelcashParams, &coinsView, &cs_main);
             builder.SetExpiryHeight(targetHeight_ + CONSOLIDATION_EXPIRY_DELTA);
             LogPrint("zrpcunsafe", "%s: Beginning creating transaction with Sapling output amount=%s\n", getId(), FormatMoney(amountToSend - fConsolidationTxFee));
 
             // Select Sapling notes
             std::vector<SaplingOutPoint> ops;
-            std::vector<libzcash::SaplingNote> notes;
+            std::vector<libzelcash::SaplingNote> notes;
             for (auto fromNote : fromNotes) {
                 ops.push_back(fromNote.op);
                 notes.push_back(fromNote.note);

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.h
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.h
@@ -1,0 +1,37 @@
+#include "amount.h"
+#include "asyncrpcoperation.h"
+#include "univalue.h"
+#include "zcash/Address.hpp"
+#include "zcash/zip32.h"
+
+//Default fee used for consolidation transactions
+static const CAmount DEFAULT_CONSOLIDATION_FEE = 0;
+extern CAmount fConsolidationTxFee;
+extern bool fConsolidationMapUsed;
+
+class AsyncRPCOperation_saplingconsolidation : public AsyncRPCOperation
+{
+public:
+    AsyncRPCOperation_saplingconsolidation(int targetHeight);
+    virtual ~AsyncRPCOperation_saplingconsolidation();
+
+    // We don't want to be copied or moved around
+    AsyncRPCOperation_saplingconsolidation(AsyncRPCOperation_saplingconsolidation const&) = delete;            // Copy construct
+    AsyncRPCOperation_saplingconsolidation(AsyncRPCOperation_saplingconsolidation&&) = delete;                 // Move construct
+    AsyncRPCOperation_saplingconsolidation& operator=(AsyncRPCOperation_saplingconsolidation const&) = delete; // Copy assign
+    AsyncRPCOperation_saplingconsolidation& operator=(AsyncRPCOperation_saplingconsolidation&&) = delete;      // Move assign
+
+    virtual void main();
+
+    virtual void cancel();
+
+    virtual UniValue getStatus() const;
+
+private:
+    int targetHeight_;
+
+    bool main_impl();
+
+    void setConsolidationResult(int numTxCreated, const CAmount& amountConsolidated, const std::vector<std::string>& consolidationTxIds);
+
+};

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.h
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.h
@@ -1,8 +1,8 @@
 #include "amount.h"
 #include "asyncrpcoperation.h"
 #include "univalue.h"
-#include "zcash/Address.hpp"
-#include "zcash/zip32.h"
+#include "zelcash/Address.hpp"
+#include "zelcash/zip32.h"
 
 //Default fee used for consolidation transactions
 static const CAmount DEFAULT_CONSOLIDATION_FEE = 0;

--- a/src/wallet/asyncrpcoperation_saplingmigration.cpp
+++ b/src/wallet/asyncrpcoperation_saplingmigration.cpp
@@ -104,8 +104,9 @@ bool AsyncRPCOperation_saplingmigration::main_impl() {
     CCoinsViewCache coinsView(pcoinsTip);
     do {
         CAmount amountToSend = chooseAmount(availableFunds);
-        auto builder = TransactionBuilder(consensusParams, targetHeight_, MIGRATION_EXPIRY_DELTA, pwalletMain, pzelcashParams,
+        auto builder = TransactionBuilder(consensusParams, targetHeight_, pwalletMain, pzelcashParams,
                                           &coinsView, &cs_main);
+        builder.SetExpiryHeight(targetHeight_ + MIGRATION_EXPIRY_DELTA);
         LogPrint("zrpcunsafe", "%s: Beginning creating transaction with Sapling output amount=%s\n", getId(), FormatMoney(amountToSend - FEE));
         std::vector<SproutNoteEntry> fromNotes;
         CAmount fromNoteAmount = 0;
@@ -194,6 +195,17 @@ libzelcash::SaplingPaymentAddress AsyncRPCOperation_saplingmigration::getMigrati
         assert(saplingAddress != nullptr); // This is checked in init.cpp
         return *saplingAddress;
     }
+
+    // Derive the address for Sapling account 0
+    auto m = libzelcash::SaplingExtendedSpendingKey::Master(seed);
+    uint32_t bip44CoinType = Params().BIP44CoinType();
+
+    // We use a fixed keypath scheme of m/32'/coin_type'/account'
+    // Derive m/32'
+    auto m_32h = m.Derive(32 | ZIP32_HARDENED_KEY_LIMIT);
+    // Derive m/32'/coin_type'
+    auto m_32h_cth = m_32h.Derive(bip44CoinType | ZIP32_HARDENED_KEY_LIMIT);
+
 
     // Derive m/32'/coin_type'/0'
     libzelcash::SaplingExtendedSpendingKey xsk = m_32h_cth.Derive(0 | ZIP32_HARDENED_KEY_LIMIT);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -89,7 +89,7 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
         nEnvFlags |= DB_PRIVATE;
 
     dbenv->set_lg_dir(pathLogDir.string().c_str());
-    dbenv->set_cachesize(1, 0x100000, 1); // 1 MiB should be enough for just the wallet, Increased by 1 GB
+    dbenv->set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
     dbenv->set_lg_bsize(0x10000);
     dbenv->set_lg_max(1048576);
     dbenv->set_lk_max_locks(40000);
@@ -181,8 +181,8 @@ bool CDBEnv::Compact(const std::string& strFile)
     if (mapDb[strFile] != NULL) {
         Db* pdb = mapDb[strFile];
         result = pdb->compact(NULL, NULL, NULL, pdbcompact, DB_FREE_SPACE, NULL);
-        delete pdb;
-        mapDb[strFile] = NULL;
+        // delete pdb;
+        // mapDb[strFile] = NULL;
 
       switch (result)
       {

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -89,7 +89,7 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
         nEnvFlags |= DB_PRIVATE;
 
     dbenv->set_lg_dir(pathLogDir.string().c_str());
-    dbenv->set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    dbenv->set_cachesize(1, 0x100000, 1); // 1 MiB should be enough for just the wallet, Increased by 1 GB
     dbenv->set_lg_bsize(0x10000);
     dbenv->set_lg_max(1048576);
     dbenv->set_lk_max_locks(40000);
@@ -163,6 +163,55 @@ CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, bool (*recoverFu
     // Try to recover:
     bool fRecovered = (*recoverFunc)(*this, strFile);
     return (fRecovered ? RECOVER_OK : RECOVER_FAIL);
+}
+
+bool CDBEnv::Compact(const std::string& strFile)
+{
+    LOCK(cs_db);
+
+    DB_COMPACT dbcompact;
+    dbcompact.compact_fillpercent = 80;
+    dbcompact.compact_pages = DB_MAX_PAGES;
+    dbcompact.compact_timeout = 0;
+
+    DB_COMPACT *pdbcompact;
+    pdbcompact = &dbcompact;
+
+    int result = 1;
+    if (mapDb[strFile] != NULL) {
+        Db* pdb = mapDb[strFile];
+        result = pdb->compact(NULL, NULL, NULL, pdbcompact, DB_FREE_SPACE, NULL);
+        delete pdb;
+        mapDb[strFile] = NULL;
+
+      switch (result)
+      {
+        case DB_LOCK_DEADLOCK:
+          LogPrint("db","Deadlock %i\n", result);
+          break;
+        case DB_LOCK_NOTGRANTED:
+          LogPrint("db","Lock Not Granted %i\n", result);
+          break;
+        case DB_REP_HANDLE_DEAD:
+          LogPrint("db","Handle Dead %i\n", result);
+          break;
+        case DB_REP_LOCKOUT:
+          LogPrint("db","Rep Lockout %i\n", result);
+          break;
+        case EACCES:
+          LogPrint("db","Eacces %i\n", result);
+          break;
+        case EINVAL:
+          LogPrint("db","Error Invalid %i\n", result);
+          break;
+        case 0:
+          LogPrint("db","Wallet Compact Sucessful\n");
+          break;
+        default:
+          LogPrint("db","Compact result int %i\n", result);
+      }
+    }
+    return (result == 0);
 }
 
 bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<CDBEnv::KeyValPair>& vResult)

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -63,6 +63,7 @@ public:
      * NOTE: reads the entire database into memory, so cannot be used
      * for huge databases.
      */
+    bool Compact(const std::string& strFile);
     typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char> > KeyValPair;
     bool Salvage(const std::string& strFile, bool fAggressive, std::vector<KeyValPair>& vResult);
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -51,11 +51,8 @@ public:
         return CCryptoKeyStore::Unlock(vMasterKeyIn);
     }
 
-    void IncrementNoteWitnesses(const CBlockIndex* pindex,
-                                const CBlock* pblock,
-                                SproutMerkleTree& sproutTree,
-                                SaplingMerkleTree& saplingTree) {
-        CWallet::IncrementNoteWitnesses(pindex, pblock, sproutTree, saplingTree);
+    void BuildWitnessCache(const CBlockIndex* pindex, bool witnessOnly) {
+        CWallet::BuildWitnessCache(pindex, witnessOnly);
     }
     void DecrementNoteWitnesses(const CBlockIndex* pindex) {
         CWallet::DecrementNoteWitnesses(pindex);
@@ -130,7 +127,7 @@ std::pair<JSOutPoint, SaplingOutPoint> CreateValidBlock(TestWallet& wallet,
     wallet.AddToWallet(wtx, true, NULL);
 
     block.vtx.push_back(wtx);
-    wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
+    wallet.BuildWitnessCache(&index, false);
 
     return std::make_pair(jsoutpt, saplingNotes[0]);
 }
@@ -682,8 +679,8 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     wallet.AddToWallet(wtx, true, NULL);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
-    wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
+    wallet.BuildWitnessCache(&fakeIndex, false);
+    wallet.UpdateNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
     uint256 hash = wtx.GetHash();
@@ -934,8 +931,8 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     }
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, testNote.tree);
-    wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
+    wallet.BuildWitnessCache(&fakeIndex, false);
+    wallet.UpdateNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
     uint256 hash = wtx.GetHash();
@@ -1044,8 +1041,8 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     // Simulate receiving new block and ChainTip signal.
     // This triggers calculation of nullifiers for notes belonging to this wallet
     // in the output descriptions of wtx.
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
-    wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
+    wallet.BuildWitnessCache(&fakeIndex, false);
+    wallet.UpdateNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
     wtx = wallet.mapWallet[wtx.GetHash()];
@@ -1178,7 +1175,7 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
     CBlockIndex index(block);
     SproutMerkleTree sproutTree;
     SaplingMerkleTree saplingTree;
-    wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
+    wallet.BuildWitnessCache(&index, false);
 
     ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -1248,7 +1245,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         index2.nHeight = 2;
         SproutMerkleTree sproutTree2 {sproutTree};
         SaplingMerkleTree saplingTree2 {saplingTree};
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree2, saplingTree2);
+        wallet.BuildWitnessCache(&index2, false);
 
         auto anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors2.first, anchors2.second);
@@ -1269,7 +1266,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         EXPECT_NE(anchors1.second, anchors3.second);
 
         // Re-incrementing with the same block should give the same result
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
+        wallet.BuildWitnessCache(&index2, false);
         auto anchors4 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors4.first, anchors4.second);
 
@@ -1279,7 +1276,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         EXPECT_EQ(anchors2.second, anchors4.second);
 
         // Incrementing with the same block again should not change the cache
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
+        wallet.BuildWitnessCache(&index2, false);
         std::vector<boost::optional<SproutWitness>> sproutWitnesses5;
         std::vector<boost::optional<SaplingWitness>> saplingWitnesses5;
 
@@ -1362,7 +1359,7 @@ TEST(WalletTests, CachedWitnessesDecrementFirst) {
         EXPECT_NE(anchors2.second, anchors4.second);
 
         // Re-incrementing with the same block should give the same result
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
+        wallet.BuildWitnessCache(&index2, false);
 
         auto anchors5 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -1419,7 +1416,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
     for (size_t i = 0; i < numBlocks; i++) {
         SproutMerkleTree sproutRiPrevTree {sproutRiTree};
         SaplingMerkleTree saplingRiPrevTree {saplingRiTree};
-        wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiTree, saplingRiTree);
+        wallet.BuildWitnessCache(&indices[i], false);
 
         auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         for (size_t j = 0; j < numBlocks; j++) {
@@ -1446,7 +1443,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
             }
 
             {
-                wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiPrevTree, saplingRiPrevTree);
+                wallet.BuildWitnessCache(&indices[i], false);
                 auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
                 for (size_t j = 0; j < numBlocks; j++) {
                     EXPECT_TRUE((bool) sproutWitnesses[j]);
@@ -1820,8 +1817,8 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
     wallet.AddToWallet(wtx, true, NULL);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, testNote.tree);
-    wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
+    wallet.BuildWitnessCache(&fakeIndex, false);
+    wallet.UpdateNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
     uint256 hash = wtx.GetHash();
@@ -1849,7 +1846,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
 
     EXPECT_EQ(2, wtx2.mapSaplingNoteData.size());
     EXPECT_EQ(1, wtx2.mapSaplingNoteData[sop0].witnesses.size());    // wtx2 has fake witness for payment output
-    EXPECT_EQ(0, wtx2.mapSaplingNoteData[sop1].witnesses.size());    // wtx2 never had incrementnotewitness called
+    EXPECT_EQ(0, wtx2.mapSaplingNoteData[sop1].witnesses.size());    // wtx2 never had BuildWitnessCache called
 
     // After updating, they should be the same
     EXPECT_TRUE(wallet.UpdatedNoteData(wtx2, wtx));
@@ -1965,8 +1962,8 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     wallet.AddToWallet(wtx, true, NULL);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
-    wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
+    wallet.BuildWitnessCache(&fakeIndex, false);
+    wallet.UpdateNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
     uint256 hash = wtx.GetHash();

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -393,7 +393,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     ASSERT_TRUE(nf);
     uint256 nullifier = nf.get();
 
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+    auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 50000, {});
     builder.SetFee(0);
@@ -520,7 +520,7 @@ TEST(WalletTests, FindMySaplingNotes) {
     auto testNote = GetTestSaplingNote(pa, 50000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+    auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(fvk.ovk, pa, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
@@ -652,7 +652,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     auto witness = saplingTree.witness();
 
     // Generate tx to create output note B
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+    auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 35000, {});
     auto tx = builder.Build().GetTxOrThrow();
@@ -706,13 +706,13 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     anchor = saplingTree.root();
 
     // Create transaction to spend note B
-    auto builder2 = TransactionBuilder(consensusParams, 2, expiryDelta);
+    auto builder2 = TransactionBuilder(consensusParams, 2);
     builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder2.AddSaplingOutput(fvk.ovk, pk, 20000, {});
     auto tx2 = builder2.Build().GetTxOrThrow();
 
     // Create conflicting transaction which also spends note B
-    auto builder3 = TransactionBuilder(consensusParams, 2, expiryDelta);
+    auto builder3 = TransactionBuilder(consensusParams, 2);
     builder3.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder3.AddSaplingOutput(fvk.ovk, pk, 19999, {});
     auto tx3 = builder3.Build().GetTxOrThrow();
@@ -799,7 +799,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     auto testNote = GetTestSaplingNote(pa, 50000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+    auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk,  testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(fvk.ovk, pa, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
@@ -882,7 +882,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     auto testNote = GetTestSaplingNote(pa, 50000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+    auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(fvk.ovk, pa, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
@@ -1010,7 +1010,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     auto witness = saplingTree.witness();
 
     // Generate transaction, which sends funds to note B
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+    auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
@@ -1080,7 +1080,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     anchor = saplingTree.root();
 
     // Create transaction to spend note B
-    auto builder2 = TransactionBuilder(consensusParams, 2, expiryDelta);
+    auto builder2 = TransactionBuilder(consensusParams, 2);
     builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder2.AddSaplingOutput(fvk.ovk, pk, 12500, {});
     auto tx2 = builder2.Build().GetTxOrThrow();
@@ -1785,7 +1785,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
     auto testNote = GetTestSaplingNote(pa, 50000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
+    auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(fvk.ovk, pa2, 25000, {});
     auto tx = builder.Build().GetTxOrThrow();
@@ -1926,7 +1926,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
 
     // Generate shielding tx from transparent to Sapling
     // 0.0005 t-ZEL in, 0.0004 z-ZEL out, 0.0001 t-ZEL fee
-    auto builder = TransactionBuilder(consensusParams, 1, expiryDelta, &keystore);
+    auto builder = TransactionBuilder(consensusParams, 1, &keystore);
     builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000);
     builder.AddSaplingOutput(fvk.ovk, pk, 40000, {});
     auto tx1 = builder.Build().GetTxOrThrow();
@@ -1981,7 +1981,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
 
     // Create a Sapling-only transaction
     // 0.0004 z-ZEL in, 0.00025 z-ZEL out, 0.0001 t-ZEL fee, 0.00005 z-ZEL change
-    auto builder2 = TransactionBuilder(consensusParams, 2, expiryDelta);
+    auto builder2 = TransactionBuilder(consensusParams, 2);
     builder2.AddSaplingSpend(expsk, note, anchor, witness);
     builder2.AddSaplingOutput(fvk.ovk, pk, 25000, {});
     auto tx2 = builder2.Build().GetTxOrThrow();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3905,7 +3905,7 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     // Builder (used if Sapling addresses are involved)
     boost::optional<TransactionBuilder> builder;
     if (noSproutAddrs) {
-        builder = TransactionBuilder(Params().GetConsensus(), nextBlockHeight, expiryDelta, pwalletMain);
+        builder = TransactionBuilder(Params().GetConsensus(), nextBlockHeight, pwalletMain);
     }
 
     // Contextual transaction we will build on
@@ -4261,7 +4261,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
 
     // Builder (used if Sapling addresses are involved)
     TransactionBuilder builder = TransactionBuilder(
-        Params().GetConsensus(), nextBlockHeight, expiryDelta, pwalletMain);
+            Params().GetConsensus(), nextBlockHeight, pwalletMain);
 
     // Contextual transaction we will build on
     // (used if no Sapling addresses are involved)
@@ -4694,7 +4694,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     // Builder (used if Sapling addresses are involved)
     boost::optional<TransactionBuilder> builder;
     if (isToSaplingZaddr || saplingNoteInputs.size() > 0) {
-        builder = TransactionBuilder(Params().GetConsensus(), nextBlockHeight, expiryDelta, pwalletMain);
+        builder = TransactionBuilder(Params().GetConsensus(), nextBlockHeight, pwalletMain);
     }
     // Create operation and add to global queue
     std::shared_ptr<AsyncRPCQueue> q = getAsyncRPCQueue();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1166,7 +1166,7 @@ int CWallet::SaplingWitnessMinimumHeight(const uint256& nullifier, int nWitnessH
 
 int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessOnly)
 {
-  LOCK2(cs_wallet,cs_main);
+  LOCK2(cs_main, cs_wallet);
 
   int nWitnessTxIncrement = 0;
   int nWitnessTotalTxCount = mapWallet.size();
@@ -1372,7 +1372,7 @@ int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessO
 void CWallet::BuildWitnessCache(const CBlockIndex* pindex, bool witnessOnly)
 {
 
-  LOCK2(cs_wallet,cs_main);
+  LOCK2(cs_main, cs_wallet);
 
   int startHeight = VerifyAndSetInitialWitness(pindex, witnessOnly) + 1;
 
@@ -2759,7 +2759,7 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
  */
 
 void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> &mapSorted, int64_t &maxOrderPos) {
-    LOCK2(cs_wallet,cs_main);
+    LOCK2(cs_main, cs_wallet);
 
     int maxSortNumber = chainActive.Tip()->nHeight + 1;
 
@@ -2785,7 +2785,7 @@ void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> 
  */
 
 void CWallet::UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx> &mapSorted, bool resetOrder) {
-  LOCK2(cs_wallet,cs_main);
+  LOCK2(cs_main, cs_wallet);
 
   int64_t previousPosition = 0;
   std::map<const uint256, CWalletTx> mapUpdatedTxs;
@@ -2842,7 +2842,7 @@ void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs) {
 
 void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
 
-      LOCK2(cs_wallet,cs_main);
+      LOCK2(cs_main, cs_wallet);
 
       int nDeleteAfter = (int)fDeleteTransactionsAfterNBlocks;
       bool runCompact = false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -35,6 +35,8 @@
 #include <boost/thread.hpp>
 #include <zelnode/zelnode.h>
 
+#include <malloc.h>
+
 using namespace std;
 using namespace libzelcash;
 
@@ -2843,6 +2845,9 @@ void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs) {
             return;
         }
     }
+    
+    // Miodrag: release memory back to the OS
+    malloc_trim(0);
 }
 
 void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -114,7 +114,7 @@ libzelcash::SproutPaymentAddress CWallet::GenerateNewSproutZKey()
 }
 
 // Generate a new Sapling spending key and return its public payment address
-SaplingPaymentAddress CWallet::GenerateNewSaplingZKey()
+SaplingPaymentAddress CWallet::GenerateNewSaplingZKey(bool resetCounter)
 {
     AssertLockHeld(cs_wallet); // mapSaplingZKeyMetadata
 
@@ -138,6 +138,11 @@ SaplingPaymentAddress CWallet::GenerateNewSaplingZKey()
 
     // Derive account key at next index, skip keys already known to the wallet
     libzelcash::SaplingExtendedSpendingKey xsk;
+
+    //reset saplingAccountCounter
+    if (resetCounter)
+      hdChain.saplingAccountCounter = 0;
+
     do
     {
         xsk = m_32h_cth.Derive(hdChain.saplingAccountCounter | ZIP32_HARDENED_KEY_LIMIT);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2762,61 +2762,61 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
  * Transactions can get out of order when they are deleted and subsequently
  * re-added during intial load rescan.
  */
-
-void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> &mapSorted, int64_t &maxOrderPos) {
+void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, int64_t &maxOrderPos)
+{
     LOCK2(cs_main, cs_wallet);
 
     int maxSortNumber = chainActive.Tip()->nHeight + 1;
 
     for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {
-        CWalletTx wtx = it->second;
-        int confirms = wtx.GetDepthInMainChain();
-        maxOrderPos = max(maxOrderPos, wtx.nOrderPos);
+        CWalletTx* pwtx = &(it->second);
+        int confirms = pwtx->GetDepthInMainChain();
+        maxOrderPos = max(maxOrderPos, pwtx->nOrderPos);
 
         if (confirms > 0) {
-            int wtxHeight = mapBlockIndex[wtx.hashBlock]->nHeight;
-            auto key = std::make_pair(wtxHeight, wtx.nIndex);
-            mapSorted.insert(make_pair(key, wtx));
+            int wtxHeight = mapBlockIndex[pwtx->hashBlock]->nHeight;
+            auto key = std::make_pair(wtxHeight, pwtx->nIndex);
+            mapSorted.insert(make_pair(key, pwtx));
         }
         else {
-          auto key = std::make_pair(maxSortNumber, 0);
-          mapSorted.insert(std::make_pair(key, wtx));
-          maxSortNumber++;
+            auto key = std::make_pair(maxSortNumber, 0);
+            mapSorted.insert(std::make_pair(key, pwtx));
+            maxSortNumber++;
         }
     }
 }
  /**Update the nOrderPos with passed in ordered map.
  */
 
-void CWallet::UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx> &mapSorted, bool resetOrder) {
+void CWallet::UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, bool resetOrder) {
   LOCK2(cs_main, cs_wallet);
 
   int64_t previousPosition = 0;
-  std::map<const uint256, CWalletTx> mapUpdatedTxs;
+  std::map<const uint256, CWalletTx*> mapUpdatedTxs;
 
   //Check the postion of each transaction relative to the previous one.
-  for (map<std::pair<int,int>, CWalletTx>::iterator it = mapSorted.begin(); it != mapSorted.end(); ++it) {
-      CWalletTx wtx = it->second;
-      const uint256 wtxid = wtx.GetHash();
+  for (map<std::pair<int,int>, CWalletTx*>::iterator it = mapSorted.begin(); it != mapSorted.end(); ++it) {
+      CWalletTx* pwtx = it->second;
+      const uint256 wtxid = pwtx->GetHash();
 
-      if (wtx.nOrderPos <= previousPosition || resetOrder) {
+      if (pwtx->nOrderPos <= previousPosition || resetOrder) {
           previousPosition++;
-          wtx.nOrderPos = previousPosition;
-          mapUpdatedTxs.insert(std::make_pair(wtxid, wtx));
+          pwtx->nOrderPos = previousPosition;
+          mapUpdatedTxs.insert(std::make_pair(wtxid, pwtx));
       }
       else {
-          previousPosition = wtx.nOrderPos;
+          previousPosition = pwtx->nOrderPos;
       }
   }
 
   //Update transactions nOrderPos for transactions that changed
   CWalletDB walletdb(strWalletFile, "r+", false);
-  for (map<const uint256, CWalletTx>::iterator it = mapUpdatedTxs.begin(); it != mapUpdatedTxs.end(); ++it) {
-    CWalletTx wtx = it->second;
-    LogPrint("deletetx","Reorder Tx - Updating Positon to %i for Tx %s\n ", wtx.nOrderPos, wtx.GetHash().ToString());
-    wtx.WriteToDisk(&walletdb);
-    mapWallet[wtx.GetHash()].nOrderPos = wtx.nOrderPos;
+  for (map<const uint256, CWalletTx*>::iterator it = mapUpdatedTxs.begin(); it != mapUpdatedTxs.end(); ++it) {
+    CWalletTx* pwtx = it->second;
+    LogPrint("deletetx","Reorder Tx - Updating Positon to %i for Tx %s\n ", pwtx->nOrderPos, pwtx->GetHash().ToString());
+    pwtx->WriteToDisk(&walletdb);
+    mapWallet[pwtx->GetHash()].nOrderPos = pwtx->nOrderPos;
   }
 
   //Update Next Wallet Tx Positon
@@ -2868,7 +2868,7 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
 
         //Sort Transactions by block and block index
         int64_t maxOrderPos = 0;
-        std::map<std::pair<int,int>, CWalletTx> mapSorted;
+        std::map<std::pair<int,int>, CWalletTx*> mapSorted;
         ReorderWalletTransactions(mapSorted, maxOrderPos);
         if (maxOrderPos > int64_t(mapSorted.size())*10) {
           //reset the postion when the max postion is 10x bigger than the
@@ -2890,25 +2890,25 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
         for (auto & item : mapSorted)
         {
 
-          CWalletTx& wtx = item.second;
-          const uint256& wtxid = wtx.GetHash();
+          CWalletTx* pwtx = item.second;
+          const uint256& wtxid = pwtx->GetHash();
           bool deleteTx = true;
           txCount += 1;
-          int wtxDepth = wtx.GetDepthInMainChain();
+          int wtxDepth = pwtx->GetDepthInMainChain();
 
           //Keep anything newer than N Blocks
           if (wtxDepth == 0)
             txUnConfirmed++;
 
           if (wtxDepth < nDeleteAfter && wtxDepth >= 0) {
-            LogPrint("deletetx","DeleteTx - Transaction above minimum depth, tx %s\n", wtx.GetHash().ToString());
+            LogPrint("deletetx","DeleteTx - Transaction above minimum depth, tx %s\n", pwtx->GetHash().ToString());
             deleteTx = false;
             txSaveCount++;
             continue;
           } else if (wtxDepth == -1) {
             //Enabled by default
             if (!fTxConflictDeleteEnabled) {
-              LogPrint("deletetx","DeleteTx - Conflict delete is not enabled tx %s\n", wtx.GetHash().ToString());
+              LogPrint("deletetx","DeleteTx - Conflict delete is not enabled tx %s\n", pwtx->GetHash().ToString());
               deleteTx = false;
               txSaveCount++;
               continue;
@@ -2918,10 +2918,10 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
           } else {
 
             //Check for unspent inputs or spend less than N Blocks ago. (Sapling)
-            for (auto & pair : wtx.mapSaplingNoteData) {
+            for (auto & pair : pwtx->mapSaplingNoteData) {
               SaplingNoteData nd = pair.second;
               if (!nd.nullifier || pwalletMain->GetSaplingSpendDepth(*nd.nullifier) <= fDeleteTransactionsAfterNBlocks) {
-                LogPrint("deletetx","DeleteTx - Unspent sapling input tx %s\n", wtx.GetHash().ToString());
+                LogPrint("deletetx","DeleteTx - Unspent sapling input tx %s\n", pwtx->GetHash().ToString());
                 deleteTx = false;
                 continue;
               }
@@ -2933,13 +2933,13 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
             }
 
             //Check for outputs that no longer have parents in the wallet. Exclude parents that are in the same transaction. (Sapling)
-            for (int i = 0; i < wtx.vShieldedSpend.size(); i++) {
-              const SpendDescription& spendDesc = wtx.vShieldedSpend[i];
+            for (int i = 0; i < pwtx->vShieldedSpend.size(); i++) {
+              const SpendDescription& spendDesc = pwtx->vShieldedSpend[i];
               if (pwalletMain->IsSaplingNullifierFromMe(spendDesc.nullifier)) {
                 const uint256& parentHash = pwalletMain->mapSaplingNullifiersToNotes[spendDesc.nullifier].hash;
                 const CWalletTx* parent = pwalletMain->GetWalletTx(parentHash);
                 if (parent != NULL && parentHash != wtxid) {
-                  LogPrint("deletetx","DeleteTx - Parent of sapling tx %s found\n", wtx.GetHash().ToString());
+                  LogPrint("deletetx","DeleteTx - Parent of sapling tx %s found\n", pwtx->GetHash().ToString());
                   deleteTx = false;
                   continue;
                 }
@@ -2952,10 +2952,10 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
             }
 
             //Check for unspent inputs or spend less than N Blocks ago. (Sprout)
-            for (auto & pair : wtx.mapSproutNoteData) {
+            for (auto & pair : pwtx->mapSproutNoteData) {
               SproutNoteData nd = pair.second;
               if (!nd.nullifier || pwalletMain->GetSproutSpendDepth(*nd.nullifier) <= fDeleteTransactionsAfterNBlocks) {
-                LogPrint("deletetx","DeleteTx - Unspent sprout input tx %s\n", wtx.GetHash().ToString());
+                LogPrint("deletetx","DeleteTx - Unspent sprout input tx %s\n", pwtx->GetHash().ToString());
                 deleteTx = false;
                 continue;
               }
@@ -2967,15 +2967,15 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
             }
 
             //Check for outputs that no longer have parents in the wallet. Exclude parents that are in the same transaction. (Sprout)
-            for (int i = 0; i < wtx.vJoinSplit.size(); i++) {
-              const JSDescription& jsdesc = wtx.vJoinSplit[i];
+            for (int i = 0; i < pwtx->vJoinSplit.size(); i++) {
+              const JSDescription& jsdesc = pwtx->vJoinSplit[i];
               for (const uint256 &nullifier : jsdesc.nullifiers) {
                 // JSOutPoint op = pwalletMain->mapSproutNullifiersToNotes[nullifier];
                 if (pwalletMain->IsSproutNullifierFromMe(nullifier)) {
                   const uint256& parentHash = pwalletMain->mapSproutNullifiersToNotes[nullifier].hash;
                   const CWalletTx* parent = pwalletMain->GetWalletTx(parentHash);
                   if (parent != NULL && parentHash != wtxid) {
-                    LogPrint("deletetx","DeleteTx - Parent of sprout tx %s found\n", wtx.GetHash().ToString());
+                    LogPrint("deletetx","DeleteTx - Parent of sprout tx %s found\n", pwtx->GetHash().ToString());
                     deleteTx = false;
                     continue;
                   }
@@ -2989,12 +2989,12 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
             }
 
             //Check for unspent inputs or spend less than N Blocks ago. (Transparent)
-            for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+            for (unsigned int i = 0; i < pwtx->vout.size(); i++) {
               CTxDestination address;
-              ExtractDestination(wtx.vout[i].scriptPubKey, address);
-              if(IsMine(wtx.vout[i])) {
-                if (pwalletMain->GetSpendDepth(wtx.GetHash(), i) <= fDeleteTransactionsAfterNBlocks) {
-                  LogPrint("deletetx","DeleteTx - Unspent transparent input tx %s\n", wtx.GetHash().ToString());
+              ExtractDestination(pwtx->vout[i].scriptPubKey, address);
+              if(IsMine(pwtx->vout[i])) {
+                if (pwalletMain->GetSpendDepth(pwtx->GetHash(), i) <= fDeleteTransactionsAfterNBlocks) {
+                  LogPrint("deletetx","DeleteTx - Unspent transparent input tx %s\n", pwtx->GetHash().ToString());
                   deleteTx = false;
                   continue;
                 }
@@ -3007,12 +3007,12 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
             }
 
             //Chcek for output with that no longer have parents in the wallet. (Transparent)
-            for (int i = 0; i < wtx.vin.size(); i++) {
-              const CTxIn& txin = wtx.vin[i];
+            for (int i = 0; i < pwtx->vin.size(); i++) {
+              const CTxIn& txin = pwtx->vin[i];
               const uint256& parentHash = txin.prevout.hash;
               const CWalletTx* parent = pwalletMain->GetWalletTx(txin.prevout.hash);
               if (parent != NULL && parentHash != wtxid) {
-                LogPrint("deletetx","DeleteTx - Parent of transparent tx %s found\n", wtx.GetHash().ToString());
+                LogPrint("deletetx","DeleteTx - Parent of transparent tx %s found\n", pwtx->GetHash().ToString());
                 deleteTx = false;
                 continue;
               }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -35,7 +35,9 @@
 #include <boost/thread.hpp>
 #include <zelnode/zelnode.h>
 
+#ifdef __linux__ //linux only
 #include <malloc.h>
+#endif
 
 using namespace std;
 using namespace libzelcash;
@@ -2845,9 +2847,11 @@ void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs) {
             return;
         }
     }
-    
-    // Miodrag: release memory back to the OS
+
+    // Miodrag: release memory back to the OS, only works on linux
+    #ifdef __linux__
     malloc_trim(0);
+    #endif
 }
 
 void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1171,6 +1171,7 @@ int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessO
   int nWitnessTxIncrement = 0;
   int nWitnessTotalTxCount = mapWallet.size();
   int nMinimumHeight = pindex->nHeight;
+  bool walletHasNotes = false; //Use to enable z_sendmany when no notes are present
 
   for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
     nWitnessTxIncrement += 1;
@@ -1179,6 +1180,7 @@ int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessO
       continue;
 
     if (wtxItem.second.GetDepthInMainChain() > 0) {
+      walletHasNotes = true;
       auto wtxHash = wtxItem.second.GetHash();
       int wtxHeight = mapBlockIndex[wtxItem.second.hashBlock]->nHeight;
 
@@ -1360,6 +1362,9 @@ int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessO
       }
     }
   }
+  //enable z_sendmany when the wallet has no Notes
+  if (!walletHasNotes)
+    initWitnessesBuilt = true;
 
   return nMinimumHeight;
 }
@@ -1460,6 +1465,8 @@ void CWallet::BuildWitnessCache(const CBlockIndex* pindex, bool witnessOnly)
 
   }
 
+  //Set witnessBuilt to true to allow zsendmany to run
+  initWitnessesBuilt = true;
 }
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1370,7 +1370,7 @@ int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessO
     }
   }
   //enable z_sendmany when the wallet has no Notes
-  if (!walletHasNotes)
+  if (!walletHasNotes || nMinimumHeight == pindex->nHeight)
     initWitnessesBuilt = true;
 
   return nMinimumHeight;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -657,9 +657,11 @@ void CWallet::AddPendingSaplingMigrationTx(const CTransaction& tx) {
 }
 
 void CWallet::RunSaplingConsolidation(int blockHeight) {
-    if (!Params().GetConsensus().NetworkUpgradeActive(blockHeight, Consensus::UPGRADE_SAPLING)) {
+
+    if (!NetworkUpgradeActive(blockHeight, Params().GetConsensus(), Consensus::UPGRADE_KAMATA)) {
         return;
     }
+
     LOCK(cs_wallet);
     if (!fSaplingConsolidationEnabled) {
         return;
@@ -1697,7 +1699,7 @@ void CWallet::UpdateSproutNullifierNoteMapWithTx(CWalletTx& wtx) {
             if (GetNoteDecryptor(nd.address, dec)) {
                 auto i = item.first.js;
                 auto hSig = wtx.vJoinSplit[i].h_sig(
-                    *pzcashParams, wtx.joinSplitPubKey);
+                    *pzelcashParams, wtx.joinSplitPubKey);
                 auto optNullifier = GetSproutNoteNullifier(
                     wtx.vJoinSplit[i],
                     item.second.address,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -46,6 +46,11 @@ unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = true;
 bool fSendFreeTransactions = false;
 bool fPayAtLeastCustomFee = true;
+bool fTxDeleteEnabled = false;
+bool fTxConflictDeleteEnabled = false;
+int fDeleteInterval = DEFAULT_TX_DELETE_INTERVAL;
+unsigned int fDeleteTransactionsAfterNBlocks = DEFAULT_TX_RETENTION_BLOCKS;
+unsigned int fKeepLastNTransactions = DEFAULT_TX_RETENTION_LASTTX;
 
 /**
  * Fees smaller than this (in satoshi) are considered zero fee (for transaction creation)
@@ -565,33 +570,32 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
     return false;
 }
 
-void CWallet::ChainTipAdded(const CBlockIndex *pindex,
-                            const CBlock *pblock,
-                            SproutMerkleTree sproutTree,
-                            SaplingMerkleTree saplingTree)
-{
-    IncrementNoteWitnesses(pindex, pblock, sproutTree, saplingTree);
-    UpdateSaplingNullifierNoteMapForBlock(pblock);
-}
-
-void CWallet::ChainTip(const CBlockIndex *pindex, 
+void CWallet::ChainTip(const CBlockIndex *pindex,
                        const CBlock *pblock,
                        SproutMerkleTree sproutTree,
                        SaplingMerkleTree saplingTree,
                        bool added)
 {
     if (added) {
-        ChainTipAdded(pindex, pblock, sproutTree, saplingTree);
-        // Prevent migration transactions from being created when node is syncing after launch,
         // and also when node wakes up from suspension/hibernation and incoming blocks are old.
-        if (!IsInitialBlockDownload(Params()) &&
-            pblock->GetBlockTime() > GetAdjustedTime() - 3 * 60 * 60)
+        bool initialDownloadCheck = IsInitialBlockDownload(Params());
+        if (!initialDownloadCheck &&
+            pblock->GetBlockTime() > GetAdjustedTime() - 8640) //Last 144 blocks 2.4 * 60 * 60
         {
+            BuildWitnessCache(pindex, false);
             RunSaplingMigration(pindex->nHeight);
+            DeleteWalletTransactions(pindex);
+        } else {
+            //Build intial witnesses on every block
+            BuildWitnessCache(pindex, true);
+            if (initialDownloadCheck && pindex->nHeight % fDeleteInterval == 0) {
+                DeleteWalletTransactions(pindex);
+            }
         }
+
     } else {
         DecrementNoteWitnesses(pindex);
-        UpdateSaplingNullifierNoteMapForBlock(pblock);
+        UpdateNullifierNoteMapForBlock(pblock);
     }
 }
 
@@ -929,6 +933,22 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
     return false;
 }
 
+unsigned int CWallet::GetSpendDepth(const uint256& hash, unsigned int n) const
+{
+    const COutPoint outpoint(hash, n);
+    pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
+    range = mapTxSpends.equal_range(outpoint);
+
+    for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
+    {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0)
+            return mit->second.GetDepthInMainChain(); // Spent
+    }
+    return 0;
+}
+
 /**
  * Note is spent if any non-conflicted transaction
  * spends it:
@@ -947,6 +967,20 @@ bool CWallet::IsSproutSpent(const uint256& nullifier) const {
     return false;
 }
 
+unsigned int CWallet::GetSproutSpendDepth(const uint256& nullifier) const {
+    pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
+    range = mapTxSproutNullifiers.equal_range(nullifier);
+
+    for (TxNullifiers::const_iterator it = range.first; it != range.second; ++it) {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0) {
+            return mit->second.GetDepthInMainChain(); // Spent
+        }
+    }
+    return 0;
+}
+
 bool CWallet::IsSaplingSpent(const uint256& nullifier) const {
     pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
     range = mapTxSaplingNullifiers.equal_range(nullifier);
@@ -959,6 +993,20 @@ bool CWallet::IsSaplingSpent(const uint256& nullifier) const {
         }
     }
     return false;
+}
+
+unsigned int CWallet::GetSaplingSpendDepth(const uint256& nullifier) const {
+    pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
+    range = mapTxSaplingNullifiers.equal_range(nullifier);
+
+    for (TxNullifiers::const_iterator it = range.first; it != range.second; ++it) {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0) {
+            return mit->second.GetDepthInMainChain(); // Spent
+        }
+    }
+    return 0;
 }
 
 void CWallet::AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid)
@@ -1021,222 +1069,365 @@ void CWallet::ClearNoteWitnessCache()
             item.second.witnessHeight = -1;
         }
     }
-    nWitnessCacheSize = 0;
-}
-
-template<typename NoteDataMap>
-void CopyPreviousWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        // Only increment witnesses that are behind the current height
-        if (nd->witnessHeight < indexHeight) {
-            // Check the validity of the cache
-            // The only time a note witnessed above the current height
-            // would be invalid here is during a reindex when blocks
-            // have been decremented, and we are incrementing the blocks
-            // immediately after.
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-            // Witnesses being incremented should always be either -1
-            // (never incremented or decremented) or one below indexHeight
-            assert((nd->witnessHeight == -1) || (nd->witnessHeight == indexHeight - 1));
-            // Copy the witness for the previous block if we have one
-            if (nd->witnesses.size() > 0) {
-                nd->witnesses.push_front(nd->witnesses.front());
-            }
-            if (nd->witnesses.size() > WITNESS_CACHE_SIZE) {
-                nd->witnesses.pop_back();
-            }
-        }
-    }
-}
-
-template<typename NoteDataMap>
-void AppendNoteCommitment(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize, const uint256& note_commitment)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        if (nd->witnessHeight < indexHeight && nd->witnesses.size() > 0) {
-            // Check the validity of the cache
-            // See comment in CopyPreviousWitnesses about validity.
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-            nd->witnesses.front().append(note_commitment);
-        }
-    }
-}
-
-template<typename OutPoint, typename NoteData, typename Witness>
-void WitnessNoteIfMine(std::map<OutPoint, NoteData>& noteDataMap, int indexHeight, int64_t nWitnessCacheSize, const OutPoint& key, const Witness& witness)
-{
-    if (noteDataMap.count(key) && noteDataMap[key].witnessHeight < indexHeight) {
-        auto* nd = &(noteDataMap[key]);
-        if (nd->witnesses.size() > 0) {
-            // We think this can happen because we write out the
-            // witness cache state after every block increment or
-            // decrement, but the block index itself is written in
-            // batches. So if the node crashes in between these two
-            // operations, it is possible for IncrementNoteWitnesses
-            // to be called again on previously-cached blocks. This
-            // doesn't affect existing cached notes because of the
-            // NoteData::witnessHeight checks. See #1378 for details.
-            LogPrintf("Inconsistent witness cache state found for %s\n- Cache size: %d\n- Top (height %d): %s\n- New (height %d): %s\n",
-                        key.ToString(), nd->witnesses.size(),
-                        nd->witnessHeight,
-                        nd->witnesses.front().root().GetHex(),
-                        indexHeight,
-                        witness.root().GetHex());
-            nd->witnesses.clear();
-        }
-        nd->witnesses.push_front(witness);
-        // Set height to one less than pindex so it gets incremented
-        nd->witnessHeight = indexHeight - 1;
-        // Check the validity of the cache
-        assert(nWitnessCacheSize >= nd->witnesses.size());
-    }
-}
-
-
-template<typename NoteDataMap>
-void UpdateWitnessHeights(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        if (nd->witnessHeight < indexHeight) {
-            nd->witnessHeight = indexHeight;
-            // Check the validity of the cache
-            // See comment in CopyPreviousWitnesses about validity.
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-        }
-    }
-}
-
-void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
-                                     const CBlock* pblockIn,
-                                     SproutMerkleTree& sproutTree,
-                                     SaplingMerkleTree& saplingTree)
-{
-    LOCK(cs_wallet);
-    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-       ::CopyPreviousWitnesses(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize);
-       ::CopyPreviousWitnesses(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize);
-    }
-
-    if (nWitnessCacheSize < WITNESS_CACHE_SIZE) {
-        nWitnessCacheSize += 1;
-    }
-
-    const CBlock* pblock {pblockIn};
-    CBlock block;
-    if (!pblock) {
-        ReadBlockFromDisk(block, pindex, Params().GetConsensus());
-        pblock = &block;
-    }
-
-    for (const CTransaction& tx : pblock->vtx) {
-        auto hash = tx.GetHash();
-        bool txIsOurs = mapWallet.count(hash);
-        // Sprout
-        for (size_t i = 0; i < tx.vJoinSplit.size(); i++) {
-            const JSDescription& jsdesc = tx.vJoinSplit[i];
-            for (uint8_t j = 0; j < jsdesc.commitments.size(); j++) {
-                const uint256& note_commitment = jsdesc.commitments[j];
-                sproutTree.append(note_commitment);
-
-                // Increment existing witnesses
-                for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-                    ::AppendNoteCommitment(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize, note_commitment);
-                }
-
-                // If this is our note, witness it
-                if (txIsOurs) {
-                    JSOutPoint jsoutpt {hash, i, j};
-                    ::WitnessNoteIfMine(mapWallet[hash].mapSproutNoteData, pindex->nHeight, nWitnessCacheSize, jsoutpt, sproutTree.witness());
-                }
-            }
-        }
-        // Sapling
-        for (uint32_t i = 0; i < tx.vShieldedOutput.size(); i++) {
-            const uint256& note_commitment = tx.vShieldedOutput[i].cm;
-            saplingTree.append(note_commitment);
-
-            // Increment existing witnesses
-            for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-                ::AppendNoteCommitment(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize, note_commitment);
-            }
-
-            // If this is our note, witness it
-            if (txIsOurs) {
-                SaplingOutPoint outPoint {hash, i};
-                ::WitnessNoteIfMine(mapWallet[hash].mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize, outPoint, saplingTree.witness());
-            }
-        }
-    }
-
-    // Update witness heights
-    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-        ::UpdateWitnessHeights(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize);
-        ::UpdateWitnessHeights(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize);
-    }
-
-    // For performance reasons, we write out the witness cache in
-    // CWallet::SetBestChain() (which also ensures that overall consistency
-    // of the wallet.dat is maintained).
-}
-
-template<typename NoteDataMap>
-void DecrementNoteWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        // Only decrement witnesses that are not above the current height
-        if (nd->witnessHeight <= indexHeight) {
-            // Check the validity of the cache
-            // See comment below (this would be invalid if there were a
-            // prior decrement).
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-            // Witnesses being decremented should always be either -1
-            // (never incremented or decremented) or equal to the height
-            // of the block being removed (indexHeight)
-            assert((nd->witnessHeight == -1) || (nd->witnessHeight == indexHeight));
-            if (nd->witnesses.size() > 0) {
-                nd->witnesses.pop_front();
-            }
-            // indexHeight is the height of the block being removed, so
-            // the new witness cache height is one below it.
-            nd->witnessHeight = indexHeight - 1;
-        }
-        // Check the validity of the cache
-        // Technically if there are notes witnessed above the current
-        // height, their cache will now be invalid (relative to the new
-        // value of nWitnessCacheSize). However, this would only occur
-        // during a reindex, and by the time the reindex reaches the tip
-        // of the chain again, the existing witness caches will be valid
-        // again.
-        // We don't set nWitnessCacheSize to zero at the start of the
-        // reindex because the on-disk blocks had already resulted in a
-        // chain that didn't trigger the assertion below.
-        if (nd->witnessHeight < indexHeight) {
-            // Subtract 1 to compare to what nWitnessCacheSize will be after
-            // decrementing.
-            assert((nWitnessCacheSize - 1) >= nd->witnesses.size());
-        }
-    }
 }
 
 void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex)
 {
     LOCK(cs_wallet);
     for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-        ::DecrementNoteWitnesses(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize);
-        ::DecrementNoteWitnesses(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize);
+        //Sprout
+        for (auto& item : wtxItem.second.mapSproutNoteData) {
+            auto* nd = &(item.second);
+            if (nd->nullifier && pwalletMain->GetSproutSpendDepth(*item.second.nullifier) <= WITNESS_CACHE_SIZE) {
+              // Only decrement witnesses that are not above the current height
+                if (nd->witnessHeight <= pindex->nHeight) {
+                    if (nd->witnesses.size() > 1) {
+                        // indexHeight is the height of the block being removed, so
+                        // the new witness cache height is one below it.
+                        nd->witnesses.pop_front();
+                        nd->witnessHeight = pindex->nHeight - 1;
+                    }
+                }
+            }
+        }
+        //Sapling
+        for (auto& item : wtxItem.second.mapSaplingNoteData) {
+            auto* nd = &(item.second);
+            if (nd->nullifier && pwalletMain->GetSaplingSpendDepth(*item.second.nullifier) <= WITNESS_CACHE_SIZE) {
+                // Only decrement witnesses that are not above the current height
+                if (nd->witnessHeight <= pindex->nHeight) {
+                    if (nd->witnesses.size() > 1) {
+                        // indexHeight is the height of the block being removed, so
+                        // the new witness cache height is one below it.
+                        nd->witnesses.pop_front();
+                        nd->witnessHeight = pindex->nHeight - 1;
+                    }
+                }
+            }
+        }
     }
-    nWitnessCacheSize -= 1;
-    // TODO: If nWitnessCache is zero, we need to regenerate the caches (#1302)
-    assert(nWitnessCacheSize > 0);
+}
 
-    // For performance reasons, we write out the witness cache in
-    // CWallet::SetBestChain() (which also ensures that overall consistency
-    // of the wallet.dat is maintained).
+template<typename NoteData>
+void ClearSingleNoteWitnessCache(NoteData* nd)
+{
+    nd->witnesses.clear();
+    nd->witnessHeight = -1;
+    nd->witnessRootValidated = false;
+}
+
+int CWallet::SproutWitnessMinimumHeight(const uint256& nullifier, int nWitnessHeight, int nMinimumHeight)
+{
+    if (GetSproutSpendDepth(nullifier) <= WITNESS_CACHE_SIZE) {
+        nMinimumHeight = min(nWitnessHeight, nMinimumHeight);
+    }
+    return nMinimumHeight;
+}
+
+int CWallet::SaplingWitnessMinimumHeight(const uint256& nullifier, int nWitnessHeight, int nMinimumHeight)
+{
+    if (GetSaplingSpendDepth(nullifier) <= WITNESS_CACHE_SIZE) {
+        nMinimumHeight = min(nWitnessHeight, nMinimumHeight);
+    }
+    return nMinimumHeight;
+}
+
+int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessOnly)
+{
+  LOCK2(cs_wallet,cs_main);
+
+  int nWitnessTxIncrement = 0;
+  int nWitnessTotalTxCount = mapWallet.size();
+  int nMinimumHeight = pindex->nHeight;
+
+  for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
+    nWitnessTxIncrement += 1;
+
+    if (wtxItem.second.mapSproutNoteData.empty() && wtxItem.second.mapSaplingNoteData.empty())
+      continue;
+
+    if (wtxItem.second.GetDepthInMainChain() > 0) {
+      auto wtxHash = wtxItem.second.GetHash();
+      int wtxHeight = mapBlockIndex[wtxItem.second.hashBlock]->nHeight;
+
+      for (mapSproutNoteData_t::value_type& item : wtxItem.second.mapSproutNoteData) {
+
+        auto op = item.first;
+        auto* nd = &(item.second);
+        CBlockIndex* pblockindex;
+        uint256 blockRoot;
+        uint256 witnessRoot;
+
+        if (!nd->nullifier)
+          ::ClearSingleNoteWitnessCache(nd);
+
+        if (!nd->witnesses.empty() && nd->witnessHeight > 0) {
+
+          //Skip all functions for validated witness while witness only = true
+          if (nd->witnessRootValidated && witnessOnly)
+            continue;
+
+          //Skip Validation when witness root has been validated
+          if (nd->witnessRootValidated) {
+            nMinimumHeight = SproutWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+
+          //Skip Validation when witness height is greater that block height
+          if (nd->witnessHeight > pindex->nHeight - 1) {
+            nMinimumHeight = SproutWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+
+          //Validate the witness at the witness height
+          witnessRoot = nd->witnesses.front().root();
+          pblockindex = chainActive[nd->witnessHeight];
+          blockRoot = pblockindex->hashFinalSproutRoot;
+          if (witnessRoot == blockRoot) {
+            nd->witnessRootValidated = true;
+            nMinimumHeight = SproutWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+        }
+
+        //Clear witness Cache for all other scenarios
+        pblockindex = chainActive[wtxHeight];
+        ::ClearSingleNoteWitnessCache(nd);
+
+        LogPrintf("Setting Inital Sprout Witness for tx %s, %i of %i\n", wtxHash.ToString(), nWitnessTxIncrement, nWitnessTotalTxCount);
+
+        SproutMerkleTree sproutTree;
+        blockRoot = pblockindex->pprev->hashFinalSproutRoot;
+        pcoinsTip->GetSproutAnchorAt(blockRoot, sproutTree);
+
+        //Cycle through blocks and transactions building sprout tree until the commitment needed is reached
+        const CBlock* pblock;
+        CBlock block;
+        ReadBlockFromDisk(block, pblockindex, Params().GetConsensus());
+        pblock = &block;
+
+        for (const CTransaction& tx : block.vtx) {
+          auto hash = tx.GetHash();
+
+          for (size_t i = 0; i < tx.vJoinSplit.size(); i++) {
+            const JSDescription& jsdesc = tx.vJoinSplit[i];
+            for (uint8_t j = 0; j < jsdesc.commitments.size(); j++) {
+              const uint256& note_commitment = jsdesc.commitments[j];
+
+              // Increment existing witness until the end of the block
+              if (!nd->witnesses.empty()) {
+                nd->witnesses.front().append(note_commitment);
+              }
+
+              //Only needed for intial witness
+              if (nd->witnesses.empty()) {
+                sproutTree.append(note_commitment);
+
+                // If this is our note, witness it
+                if (hash == wtxHash) {
+                  JSOutPoint outPoint {hash, i, j};
+                  if (op == outPoint) {
+                    nd->witnesses.push_front(sproutTree.witness());
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        nd->witnessHeight = pblockindex->nHeight;
+        UpdateSproutNullifierNoteMapWithTx(wtxItem.second);
+        nMinimumHeight = SproutWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+      }
+
+      for (mapSaplingNoteData_t::value_type& item : wtxItem.second.mapSaplingNoteData) {
+
+        auto op = item.first;
+        auto* nd = &(item.second);
+        CBlockIndex* pblockindex;
+        uint256 blockRoot;
+        uint256 witnessRoot;
+
+        if (!nd->nullifier)
+          ::ClearSingleNoteWitnessCache(nd);
+
+        if (!nd->witnesses.empty() && nd->witnessHeight > 0) {
+
+          //Skip all functions for validated witness while witness only = true
+          if (nd->witnessRootValidated && witnessOnly)
+            continue;
+
+          //Skip Validation when witness root has been validated
+          if (nd->witnessRootValidated) {
+            nMinimumHeight = SaplingWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+
+          //Skip Validation when witness height is greater that block height
+          if (nd->witnessHeight > pindex->nHeight - 1) {
+            nMinimumHeight = SaplingWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+
+          //Validate the witness at the witness height
+          witnessRoot = nd->witnesses.front().root();
+          pblockindex = chainActive[nd->witnessHeight];
+          blockRoot = pblockindex->hashFinalSaplingRoot;
+          if (witnessRoot == blockRoot) {
+            nd->witnessRootValidated = true;
+            nMinimumHeight = SaplingWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+        }
+
+        //Clear witness Cache for all other scenarios
+        pblockindex = chainActive[wtxHeight];
+        ::ClearSingleNoteWitnessCache(nd);
+
+        LogPrintf("Setting Inital Sapling Witness for tx %s, %i of %i\n", wtxHash.ToString(), nWitnessTxIncrement, nWitnessTotalTxCount);
+
+        SaplingMerkleTree saplingTree;
+        blockRoot = pblockindex->pprev->hashFinalSaplingRoot;
+        pcoinsTip->GetSaplingAnchorAt(blockRoot, saplingTree);
+
+        //Cycle through blocks and transactions building sapling tree until the commitment needed is reached
+        const CBlock* pblock;
+        CBlock block;
+        ReadBlockFromDisk(block, pblockindex, Params().GetConsensus());
+        pblock = &block;
+
+        for (const CTransaction& tx : block.vtx) {
+          auto hash = tx.GetHash();
+
+          // Sapling
+          for (uint32_t i = 0; i < tx.vShieldedOutput.size(); i++) {
+            const uint256& note_commitment = tx.vShieldedOutput[i].cm;
+
+            // Increment existing witness until the end of the block
+            if (!nd->witnesses.empty()) {
+              nd->witnesses.front().append(note_commitment);
+            }
+
+            //Only needed for intial witness
+            if (nd->witnesses.empty()) {
+              saplingTree.append(note_commitment);
+
+              // If this is our note, witness it
+              if (hash == wtxHash) {
+                SaplingOutPoint outPoint {hash, i};
+                if (op == outPoint) {
+                  nd->witnesses.push_front(saplingTree.witness());
+                }
+              }
+            }
+          }
+        }
+        nd->witnessHeight = pblockindex->nHeight;
+        UpdateSaplingNullifierNoteMapWithTx(wtxItem.second);
+        nMinimumHeight = SaplingWitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+      }
+    }
+  }
+
+  return nMinimumHeight;
+}
+
+void CWallet::BuildWitnessCache(const CBlockIndex* pindex, bool witnessOnly)
+{
+
+  LOCK2(cs_wallet,cs_main);
+
+  int startHeight = VerifyAndSetInitialWitness(pindex, witnessOnly) + 1;
+
+  if (startHeight > pindex->nHeight || witnessOnly) {
+    return;
+  }
+
+  uint256 sproutRoot;
+  uint256 saplingRoot;
+  CBlockIndex* pblockindex = chainActive[startHeight];
+  int height = chainActive.Height();
+
+  while (pblockindex) {
+
+    if (pblockindex->nHeight % 100 == 0 && pblockindex->nHeight < height - 5) {
+      LogPrintf("Building Witnesses for block %i %.4f complete\n", pblockindex->nHeight, pblockindex->nHeight / double(height));
+    }
+
+    SproutMerkleTree sproutTree;
+    sproutRoot = pblockindex->pprev->hashFinalSproutRoot;
+    pcoinsTip->GetSproutAnchorAt(sproutRoot, sproutTree);
+
+    SaplingMerkleTree saplingTree;
+    saplingRoot = pblockindex->pprev->hashFinalSaplingRoot;
+    pcoinsTip->GetSaplingAnchorAt(saplingRoot, saplingTree);
+
+    //Cycle through blocks and transactions building sapling tree until the commitment needed is reached
+    CBlock block;
+    ReadBlockFromDisk(block, pblockindex, Params().GetConsensus());
+
+    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
+
+      if (wtxItem.second.mapSproutNoteData.empty() && wtxItem.second.mapSaplingNoteData.empty())
+        continue;
+
+      if (wtxItem.second.GetDepthInMainChain() > 0) {
+
+        //Sprout
+        for (mapSproutNoteData_t::value_type& item : wtxItem.second.mapSproutNoteData) {
+          auto* nd = &(item.second);
+          if (nd->nullifier && nd->witnessHeight == pblockindex->nHeight - 1
+              && GetSproutSpendDepth(*item.second.nullifier) <= WITNESS_CACHE_SIZE) {
+
+
+            nd->witnesses.push_front(nd->witnesses.front());
+            while (nd->witnesses.size() > WITNESS_CACHE_SIZE) {
+                nd->witnesses.pop_back();
+            }
+
+            for (const CTransaction& tx : block.vtx) {
+              for (size_t i = 0; i < tx.vJoinSplit.size(); i++) {
+                const JSDescription& jsdesc = tx.vJoinSplit[i];
+                for (uint8_t j = 0; j < jsdesc.commitments.size(); j++) {
+                  const uint256& note_commitment = jsdesc.commitments[j];
+                  nd->witnesses.front().append(note_commitment);
+                }
+              }
+            }
+            nd->witnessHeight = pblockindex->nHeight;
+          }
+        }
+
+        //Sapling
+        for (mapSaplingNoteData_t::value_type& item : wtxItem.second.mapSaplingNoteData) {
+          auto* nd = &(item.second);
+          if (nd->nullifier && nd->witnessHeight == pblockindex->nHeight - 1
+              && GetSaplingSpendDepth(*item.second.nullifier) <= WITNESS_CACHE_SIZE) {
+
+            nd->witnesses.push_front(nd->witnesses.front());
+            while (nd->witnesses.size() > WITNESS_CACHE_SIZE) {
+                nd->witnesses.pop_back();
+            }
+
+            for (const CTransaction& tx : block.vtx) {
+              for (uint32_t i = 0; i < tx.vShieldedOutput.size(); i++) {
+                const uint256& note_commitment = tx.vShieldedOutput[i].cm;
+                nd->witnesses.front().append(note_commitment);
+              }
+            }
+            nd->witnessHeight = pblockindex->nHeight;
+          }
+        }
+      }
+    }
+
+    if (pblockindex == pindex)
+      break;
+
+    pblockindex = chainActive.Next(pblockindex);
+
+  }
+
 }
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
@@ -1438,6 +1629,48 @@ void CWallet::UpdateNullifierNoteMapWithTx(const CWalletTx& wtx)
 }
 
 /**
+ * Update mapSproutNullifiersToNotes, computing the nullifier from a cached witness if necessary.
+ */
+void CWallet::UpdateSproutNullifierNoteMapWithTx(CWalletTx& wtx) {
+    LOCK(cs_wallet);
+
+    ZCNoteDecryption dec;
+    for (mapSproutNoteData_t::value_type& item : wtx.mapSproutNoteData) {
+        SproutNoteData nd = item.second;
+
+        if (nd.witnesses.empty()) {
+            // If there are no witnesses, erase the nullifier and associated mapping.
+            if (nd.nullifier) {
+                mapSproutNullifiersToNotes.erase(nd.nullifier.get());
+            }
+            nd.nullifier = boost::none;
+        }
+        else {
+            if (GetNoteDecryptor(nd.address, dec)) {
+                auto i = item.first.js;
+                auto hSig = wtx.vJoinSplit[i].h_sig(
+                    *pzcashParams, wtx.joinSplitPubKey);
+                auto optNullifier = GetSproutNoteNullifier(
+                    wtx.vJoinSplit[i],
+                    item.second.address,
+                    dec,
+                    hSig,
+                    item.first.n);
+
+                if (!optNullifier) {
+                    // This should not happen.  If it does, maybe the position has been corrupted or miscalculated?
+                    assert(false);
+                }
+
+                uint256 nullifier = optNullifier.get();
+                mapSproutNullifiersToNotes[nullifier] = item.first;
+                item.second.nullifier = nullifier;
+            }
+        }
+    }
+}
+
+/**
  * Update mapSaplingNullifiersToNotes, computing the nullifier from a cached witness if necessary.
  */
 void CWallet::UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx) {
@@ -1484,13 +1717,14 @@ void CWallet::UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx) {
  * Iterate over transactions in a block and update the cached Sapling nullifiers
  * for transactions which belong to the wallet.
  */
-void CWallet::UpdateSaplingNullifierNoteMapForBlock(const CBlock *pblock) {
+void CWallet::UpdateNullifierNoteMapForBlock(const CBlock *pblock) {
     LOCK(cs_wallet);
 
     for (const CTransaction& tx : pblock->vtx) {
         auto hash = tx.GetHash();
         bool txIsOurs = mapWallet.count(hash);
         if (txIsOurs) {
+            UpdateSproutNullifierNoteMapWithTx(mapWallet[hash]);
             UpdateSaplingNullifierNoteMapWithTx(mapWallet[hash]);
         }
     }
@@ -2479,6 +2713,298 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
         }
     }
 }
+/**
+ * Reorder the transactions based on block hieght and block index.
+ * Transactions can get out of order when they are deleted and subsequently
+ * re-added during intial load rescan.
+ */
+
+void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> &mapSorted, int64_t &maxOrderPos) {
+    LOCK2(cs_wallet,cs_main);
+
+    int maxSortNumber = chainActive.Tip()->nHeight + 1;
+
+    for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+    {
+        CWalletTx wtx = it->second;
+        int confirms = wtx.GetDepthInMainChain();
+        maxOrderPos = max(maxOrderPos, wtx.nOrderPos);
+
+        if (confirms > 0) {
+            int wtxHeight = mapBlockIndex[wtx.hashBlock]->nHeight;
+            auto key = std::make_pair(wtxHeight, wtx.nIndex);
+            mapSorted.insert(make_pair(key, wtx));
+        }
+        else {
+          auto key = std::make_pair(maxSortNumber, 0);
+          mapSorted.insert(std::make_pair(key, wtx));
+          maxSortNumber++;
+        }
+    }
+}
+ /**Update the nOrderPos with passed in ordered map.
+ */
+
+void CWallet::UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx> &mapSorted, bool resetOrder) {
+  LOCK2(cs_wallet,cs_main);
+
+  int64_t previousPosition = 0;
+  std::map<const uint256, CWalletTx> mapUpdatedTxs;
+
+  //Check the postion of each transaction relative to the previous one.
+  for (map<std::pair<int,int>, CWalletTx>::iterator it = mapSorted.begin(); it != mapSorted.end(); ++it) {
+      CWalletTx wtx = it->second;
+      const uint256 wtxid = wtx.GetHash();
+
+      if (wtx.nOrderPos <= previousPosition || resetOrder) {
+          previousPosition++;
+          wtx.nOrderPos = previousPosition;
+          mapUpdatedTxs.insert(std::make_pair(wtxid, wtx));
+      }
+      else {
+          previousPosition = wtx.nOrderPos;
+      }
+  }
+
+  //Update transactions nOrderPos for transactions that changed
+  CWalletDB walletdb(strWalletFile, "r+", false);
+  for (map<const uint256, CWalletTx>::iterator it = mapUpdatedTxs.begin(); it != mapUpdatedTxs.end(); ++it) {
+    CWalletTx wtx = it->second;
+    LogPrint("deletetx","Reorder Tx - Updating Positon to %i for Tx %s\n ", wtx.nOrderPos, wtx.GetHash().ToString());
+    wtx.WriteToDisk(&walletdb);
+    mapWallet[wtx.GetHash()].nOrderPos = wtx.nOrderPos;
+  }
+
+  //Update Next Wallet Tx Positon
+  nOrderPosNext = previousPosition++;
+  CWalletDB(strWalletFile).WriteOrderPosNext(nOrderPosNext);
+  LogPrint("deletetx","Reorder Tx - Total Transactions Reordered %i, Next Position %i\n ", mapUpdatedTxs.size(), nOrderPosNext);
+
+}
+
+/**
+ * Delete transactions from the Wallet
+ */
+void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs) {
+    LOCK(cs_wallet);
+
+    CWalletDB walletdb(strWalletFile, "r+", false);
+
+    for (int i = 0; i< removeTxs.size(); i++) {
+        if (mapWallet.erase(removeTxs[i])) {
+            walletdb.EraseTx(removeTxs[i]);
+            LogPrint("deletetx","Delete Tx - Deleting tx %s, %i.\n", removeTxs[i].ToString(),i);
+        } else {
+            LogPrint("deletetx","Delete Tx - Deleting tx %failed.\n", removeTxs[i].ToString());
+            return;
+        }
+    }
+}
+
+void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex) {
+
+      LOCK2(cs_wallet,cs_main);
+
+      int nDeleteAfter = (int)fDeleteTransactionsAfterNBlocks;
+      bool runCompact = false;
+
+      if (pindex && fTxDeleteEnabled) {
+
+        //Check for acentries - exit function if found
+        {
+            std::list<CAccountingEntry> acentries;
+            CWalletDB walletdb(strWalletFile);
+            walletdb.ListAccountCreditDebit("*", acentries);
+            if (acentries.size() > 0) {
+                LogPrintf("deletetx not compatible to account entries\n");
+                return;
+            }
+        }
+        //delete transactions
+
+        //Sort Transactions by block and block index
+        int64_t maxOrderPos = 0;
+        std::map<std::pair<int,int>, CWalletTx> mapSorted;
+        ReorderWalletTransactions(mapSorted, maxOrderPos);
+        if (maxOrderPos > int64_t(mapSorted.size())*10) {
+          //reset the postion when the max postion is 10x bigger than the
+          //number of transactions in the wallet
+          LogPrint("deletetx","Reorder Tx - maxOrderPos %i mapSorted Size %i\n", maxOrderPos, int64_t(mapSorted.size())*10);
+          UpdateWalletTransactionOrder(mapSorted, true);
+        }
+        else {
+          UpdateWalletTransactionOrder(mapSorted, false);
+        }
+
+        //Process Transactions in sorted order
+        int txConflictCount = 0;
+        int txUnConfirmed = 0;
+        int txCount = 0;
+        int txSaveCount = 0;
+        std::vector<uint256> removeTxs;
+
+        for (auto & item : mapSorted)
+        {
+
+          CWalletTx& wtx = item.second;
+          const uint256& wtxid = wtx.GetHash();
+          bool deleteTx = true;
+          txCount += 1;
+          int wtxDepth = wtx.GetDepthInMainChain();
+
+          //Keep anything newer than N Blocks
+          if (wtxDepth == 0)
+            txUnConfirmed++;
+
+          if (wtxDepth < nDeleteAfter && wtxDepth >= 0) {
+            LogPrint("deletetx","DeleteTx - Transaction above minimum depth, tx %s\n", wtx.GetHash().ToString());
+            deleteTx = false;
+            txSaveCount++;
+            continue;
+          } else if (wtxDepth == -1) {
+            //Enabled by default
+            if (!fTxConflictDeleteEnabled) {
+              LogPrint("deletetx","DeleteTx - Conflict delete is not enabled tx %s\n", wtx.GetHash().ToString());
+              deleteTx = false;
+              txSaveCount++;
+              continue;
+            } else {
+              txConflictCount++;
+            }
+          } else {
+
+            //Check for unspent inputs or spend less than N Blocks ago. (Sapling)
+            for (auto & pair : wtx.mapSaplingNoteData) {
+              SaplingNoteData nd = pair.second;
+              if (!nd.nullifier || pwalletMain->GetSaplingSpendDepth(*nd.nullifier) <= fDeleteTransactionsAfterNBlocks) {
+                LogPrint("deletetx","DeleteTx - Unspent sapling input tx %s\n", wtx.GetHash().ToString());
+                deleteTx = false;
+                continue;
+              }
+            }
+
+            if (!deleteTx) {
+              txSaveCount++;
+              continue;
+            }
+
+            //Check for outputs that no longer have parents in the wallet. Exclude parents that are in the same transaction. (Sapling)
+            for (int i = 0; i < wtx.vShieldedSpend.size(); i++) {
+              const SpendDescription& spendDesc = wtx.vShieldedSpend[i];
+              if (pwalletMain->IsSaplingNullifierFromMe(spendDesc.nullifier)) {
+                const uint256& parentHash = pwalletMain->mapSaplingNullifiersToNotes[spendDesc.nullifier].hash;
+                const CWalletTx* parent = pwalletMain->GetWalletTx(parentHash);
+                if (parent != NULL && parentHash != wtxid) {
+                  LogPrint("deletetx","DeleteTx - Parent of sapling tx %s found\n", wtx.GetHash().ToString());
+                  deleteTx = false;
+                  continue;
+                }
+              }
+            }
+
+            if (!deleteTx) {
+              txSaveCount++;
+              continue;
+            }
+
+            //Check for unspent inputs or spend less than N Blocks ago. (Sprout)
+            for (auto & pair : wtx.mapSproutNoteData) {
+              SproutNoteData nd = pair.second;
+              if (!nd.nullifier || pwalletMain->GetSproutSpendDepth(*nd.nullifier) <= fDeleteTransactionsAfterNBlocks) {
+                LogPrint("deletetx","DeleteTx - Unspent sprout input tx %s\n", wtx.GetHash().ToString());
+                deleteTx = false;
+                continue;
+              }
+            }
+
+            if (!deleteTx) {
+              txSaveCount++;
+              continue;
+            }
+
+            //Check for outputs that no longer have parents in the wallet. Exclude parents that are in the same transaction. (Sprout)
+            for (int i = 0; i < wtx.vJoinSplit.size(); i++) {
+              const JSDescription& jsdesc = wtx.vJoinSplit[i];
+              for (const uint256 &nullifier : jsdesc.nullifiers) {
+                // JSOutPoint op = pwalletMain->mapSproutNullifiersToNotes[nullifier];
+                if (pwalletMain->IsSproutNullifierFromMe(nullifier)) {
+                  const uint256& parentHash = pwalletMain->mapSproutNullifiersToNotes[nullifier].hash;
+                  const CWalletTx* parent = pwalletMain->GetWalletTx(parentHash);
+                  if (parent != NULL && parentHash != wtxid) {
+                    LogPrint("deletetx","DeleteTx - Parent of sprout tx %s found\n", wtx.GetHash().ToString());
+                    deleteTx = false;
+                    continue;
+                  }
+                }
+              }
+            }
+
+            if (!deleteTx) {
+              txSaveCount++;
+              continue;
+            }
+
+            //Check for unspent inputs or spend less than N Blocks ago. (Transparent)
+            for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+              CTxDestination address;
+              ExtractDestination(wtx.vout[i].scriptPubKey, address);
+              if(IsMine(wtx.vout[i])) {
+                if (pwalletMain->GetSpendDepth(wtx.GetHash(), i) <= fDeleteTransactionsAfterNBlocks) {
+                  LogPrint("deletetx","DeleteTx - Unspent transparent input tx %s\n", wtx.GetHash().ToString());
+                  deleteTx = false;
+                  continue;
+                }
+              }
+            }
+
+            if (!deleteTx) {
+              txSaveCount++;
+              continue;
+            }
+
+            //Chcek for output with that no longer have parents in the wallet. (Transparent)
+            for (int i = 0; i < wtx.vin.size(); i++) {
+              const CTxIn& txin = wtx.vin[i];
+              const uint256& parentHash = txin.prevout.hash;
+              const CWalletTx* parent = pwalletMain->GetWalletTx(txin.prevout.hash);
+              if (parent != NULL && parentHash != wtxid) {
+                LogPrint("deletetx","DeleteTx - Parent of transparent tx %s found\n", wtx.GetHash().ToString());
+                deleteTx = false;
+                continue;
+              }
+            }
+
+            if (!deleteTx) {
+              txSaveCount++;
+              continue;
+            }
+
+            //Keep Last N Transactions
+            if (mapSorted.size() - txCount < fKeepLastNTransactions + txConflictCount + txUnConfirmed) {
+              LogPrint("deletetx","DeleteTx - Transaction set position %i, tx %s\n", mapSorted.size() - txCount, wtxid.ToString());
+              deleteTx = false;
+              txSaveCount++;
+              continue;
+            }
+          }
+
+          //Collect everything else for deletion
+          if (deleteTx && int(removeTxs.size()) < MAX_DELETE_TX_SIZE) {
+            removeTxs.push_back(wtxid);
+            runCompact = true;
+          }
+        }
+
+        //Delete Transactions from wallet
+        DeleteTransactions(removeTxs);
+        LogPrintf("Delete Tx - Total Transaction Count %i, Transactions Deleted %i\n ", txCount, int(removeTxs.size()));
+
+        //Compress Wallet
+        if (runCompact)
+          CWalletDB::Compact(bitdb,strWalletFile);
+      }
+}
+
 
 /**
  * Scan the block chain (starting in pindexStart) for transactions
@@ -2493,8 +3019,6 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
 
     CBlockIndex* pindex = pindexStart;
 
-    std::vector<uint256> myTxHashes;
-
     {
         LOCK2(cs_main, cs_wallet);
 
@@ -2506,6 +3030,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
         ShowProgress(_("Rescanning..."), 0); // show rescan progress in GUI as dialog or on splashscreen, if -rescan on startup
         double dProgressStart = Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), pindex, false);
         double dProgressTip = Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip(), false);
+
         while (pindex)
         {
             if (pindex->nHeight % 100 == 0 && dProgressTip - dProgressStart > 0.0)
@@ -2516,7 +3041,6 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
             BOOST_FOREACH(CTransaction& tx, block.vtx)
             {
                 if (AddToWalletIfInvolvingMe(tx, &block, fUpdate)) {
-                    myTxHashes.push_back(tx.GetHash());
                     ret++;
                 }
             }
@@ -2531,27 +3055,22 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
                     assert(pcoinsTip->GetSaplingAnchorAt(pindex->pprev->hashFinalSaplingRoot, saplingTree));
                 }
             }
-            // Increment note witness caches
-            ChainTipAdded(pindex, &block, sproutTree, saplingTree);
 
-            pindex = chainActive.Next(pindex);
+            // Build inital witness caches
+            BuildWitnessCache(pindex, true);
+
+            //Delete Transactions
+            if (pindex->nHeight % fDeleteInterval == 0)
+              DeleteWalletTransactions(pindex);
+
             if (GetTime() >= nNow + 60) {
                 nNow = GetTime();
                 LogPrintf("Still rescanning. At block %d. Progress=%f\n", pindex->nHeight, Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), pindex));
             }
+            pindex = chainActive.Next(pindex);
         }
-
-        // After rescanning, persist Sapling note data that might have changed, e.g. nullifiers.
-        // Do not flush the wallet here for performance reasons.
-        CWalletDB walletdb(strWalletFile, "r+", false);
-        for (auto hash : myTxHashes) {
-            CWalletTx wtx = mapWallet[hash];
-            if (!wtx.mapSaplingNoteData.empty()) {
-                if (!wtx.WriteToDisk(&walletdb)) {
-                    LogPrintf("Rescanning... WriteToDisk failed to update Sapling note data for: %s\n", hash.ToString());
-                }
-            }
-        }
+        //Update all witness caches
+        BuildWitnessCache(chainActive.Tip(), false);
 
         ShowProgress(_("Rescanning..."), 100); // hide progress dialog in GUI
     }
@@ -2592,7 +3111,10 @@ void CWallet::ReacceptWalletTransactions()
 
 bool CWalletTx::RelayWalletTransaction()
 {
-    assert(pwallet->GetBroadcastTransactions());
+    {
+        LOCK(pwalletMain->cs_wallet);
+        assert(pwalletMain->GetBroadcastTransactions());
+    }
     if (!IsCoinBase())
     {
         if (GetDepthInMainChain() == 0) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1110,7 +1110,7 @@ public:
       * Sapling ZKeys
       */
     //! Generates new Sapling key
-    libzelcash::SaplingPaymentAddress GenerateNewSaplingZKey();
+    libzelcash::SaplingPaymentAddress GenerateNewSaplingZKey(bool resetCounter = false);
     //! Adds Sapling spending key to the store, and saves it to disk
     bool AddSaplingZKey(
         const libzelcash::SaplingExtendedSpendingKey &key,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1165,8 +1165,8 @@ public:
          std::vector<uint256> commitments,
          std::vector<boost::optional<SproutWitness>>& witnesses,
          uint256 &final_anchor);
-    void ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> &mapSorted, int64_t &maxOrderPos);
-    void UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx> &mapSorted, bool resetOrder);
+    void ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, int64_t &maxOrderPos);
+    void UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, bool resetOrder);
     void DeleteTransactions(std::vector<uint256> &removeTxs);
     void DeleteWalletTransactions(const CBlockIndex* pindex);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -791,6 +791,9 @@ private:
     std::vector<CTransaction> pendingSaplingMigrationTxs;
     AsyncRPCOperationId saplingMigrationOperationId;
 
+    std::vector<CTransaction> pendingSaplingConsolidationTxs;
+    AsyncRPCOperationId saplingConsolidationOperationId;
+
     void AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSproutSpends(const uint256& nullifier, const uint256& wtxid);
     void AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid);
@@ -1233,6 +1236,8 @@ public:
     void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree, bool added);
     void RunSaplingMigration(int blockHeight);
     void AddPendingSaplingMigrationTx(const CTransaction& tx);
+    void RunSaplingConsolidation(int blockHeight);
+    void CommitConsolidationTx(const CTransaction& tx);
     /** Saves witness caches and best block locator to disk. */
     void SetBestChain(const CBlockLocator& loc);
     std::set<std::pair<libzelcash::PaymentAddress, uint256>> GetNullifiersForAddresses(const std::set<libzelcash::PaymentAddress> & addresses);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1162,6 +1162,11 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
     return false;
 }
 
+bool CWalletDB::Compact(CDBEnv& dbenv, const std::string& strFile)
+{
+  bool fSuccess = dbenv.Compact(strFile);
+  return fSuccess;
+}
 //
 // Try to (very carefully!) recover wallet.dat if there is a problem.
 //

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -174,6 +174,7 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTxToZap(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
+    static bool Compact(CDBEnv& dbenv, const std::string& strFile);
     static bool Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, const std::string& filename);
 

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -1079,7 +1079,11 @@ void ZelnodeCache::CheckForExpiredStartTx(const int& p_nHeight)
             if (setAddToConfirm.count(item))
                 continue;
 
+            if (!g_zelnodeCache.mapStartTxTracker.count(item)) {
+                error("%s - %d , Found map:at error", __func__, __LINE__);
+            }
             ZelnodeCacheData data = g_zelnodeCache.mapStartTxTracker.at(item);
+
             data.nStatus = ZELNODE_TX_DOS_PROTECTION;
             mapStartTxDosTracker[item] = data;
 
@@ -1130,17 +1134,17 @@ bool ZelnodeCache::CheckConfirmationHeights(const int nCurrentHeight, const COut
     // Allow ip address changes at a different interval
     if (fFluxActive) {
         if (ip != data.ip) {
-            if (nCurrentHeight - mapConfirmedZelnodeData.at(out).nLastConfirmedBlockHeight >= ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_IP_CHANGE) {
+            if (nCurrentHeight - data.nLastConfirmedBlockHeight >= ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_IP_CHANGE) {
                 return true;
             }
         }
     }
 
-    if (nCurrentHeight - mapConfirmedZelnodeData.at(out).nLastConfirmedBlockHeight <= ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT) {
+    if (nCurrentHeight - data.nLastConfirmedBlockHeight <= ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT) {
         // TODO - Remove this error message after release + 1 month and we don't see any problems
         error("%s - %d - Confirmation to soon - %s -> Current Height: %d, lastConfirmed: %d\n", __func__,
               __LINE__,
-              out.ToFullString(), nCurrentHeight, mapConfirmedZelnodeData.at(out).nLastConfirmedBlockHeight);
+              out.ToFullString(), nCurrentHeight, data.nLastConfirmedBlockHeight);
         return false;
     }
 
@@ -1583,6 +1587,9 @@ bool ZelnodeCache::Flush()
 
             // Remove from Start Tracking
             g_zelnodeCache.mapStartTxTracker.erase(item.first);
+            if (!g_zelnodeCache.mapStartTxHeights.count(data.nAddedBlockHeight)) {
+                error("%s - %d , Found map:at error", __func__, __LINE__);
+            }
             g_zelnodeCache.mapStartTxHeights.at(data.nAddedBlockHeight).erase(item.first);
 
             // Update the data (STARTED --> CONFIRM)
@@ -1599,6 +1606,9 @@ bool ZelnodeCache::Flush()
             // Because we don't automatically remove nodes that have expired from the list, to help not sort it as often
             // If this node is already in the list. We wont add it let. We need to wait for the node to be removed from the list.
             // Then we can add it to the list
+            if (!g_zelnodeCache.mapZelnodeList.count(data.nTier)) {
+                error("%s - %d , Found map:at error", __func__, __LINE__);
+            }
             if (g_zelnodeCache.mapZelnodeList.at(data.nTier).setConfirmedTxInList.count(data.collateralIn)) {
                 setRemoveFromList.insert(data.collateralIn);
                 if (data.nTier == CUMULUS) {
@@ -1702,6 +1712,9 @@ bool ZelnodeCache::Flush()
             g_zelnodeCache.mapConfirmedZelnodeData.at(item.second.second).nLastPaidHeight = item.second.first;
             g_zelnodeCache.setDirtyOutPoint.insert(item.second.second);
 
+            if (!g_zelnodeCache.mapZelnodeList.count(item.first)) {
+                error("%s - %d , Found map:at error", __func__, __LINE__);
+            }
             if (g_zelnodeCache.mapZelnodeList.at(item.first).setConfirmedTxInList.count(item.second.second)) {
                 if (g_zelnodeCache.mapZelnodeList.at(item.first).listConfirmedZelnodes.front().out == item.second.second) {
                     g_zelnodeCache.mapZelnodeList.at(item.first).listConfirmedZelnodes.pop_front();
@@ -1727,6 +1740,9 @@ bool ZelnodeCache::Flush()
             int nTier = g_zelnodeCache.mapConfirmedZelnodeData.at(item.first).nTier;
 
             bool fFoundIt = false;
+            if (!g_zelnodeCache.mapZelnodeList.count(nTier)) {
+                error("%s - %d , Found map:at error", __func__, __LINE__);
+            }
             if (g_zelnodeCache.mapZelnodeList.at(nTier).setConfirmedTxInList.count(item.first)) {
 
                 auto it = g_zelnodeCache.mapZelnodeList.at(nTier).listConfirmedZelnodes.end();


### PR DESCRIPTION
- Should decrease IO writing 
- Should stop IncrementWitness assert failures that cause a reindex to fix
- Added ability to remove transactions from database (useful for pools and other large wallets)

**Before this is released to the public, we need to run this on the pool. Some of these changes effect allowing txes into the mempool which could effect the block building process that pools use. To confirm these changes don't stop pools from building valid blocks we should first test is on the community pool to verify to doesn't break building valid blocks.** 

FYI: Just by running this on my local nodes, I am seeing Zero failed flux node confirmation transactions. This is great progress as before this code I was seeing groups of 100's of tx's failing and spamming my log files when they shouldn't have been. 
