### PR TITLE
Make zelnode type check more strict

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1629,7 +1629,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
         // Some transactions come in right after a block is mined that confirms them
         // Instead of DOSing our peers for sending us what they think are valid transactions do this check first
-        if (tx.nUpdateType == ZelnodeUpdateType::UPDATE_CONFIRM) {
+        if (tx.nType == ZELNODE_CONFIRM_TX_TYPE && tx.nUpdateType == ZelnodeUpdateType::UPDATE_CONFIRM) {
             {
                 LOCK(g_zelnodeCache.cs);
                 if (!g_zelnodeCache.CheckConfirmationHeights(nextBlockHeight - 1, tx.collateralOut, tx.ip)) {


### PR DESCRIPTION
- Someone ran into an issue where they couldn't start a zelnode. This check was failing for some reason. I am assuming it is because of how OSX assigns default values to int8_t (this is a guess)

- Fixed the problem by only checking on `tx.nType == ZELNODE_CONFIRM_TX_TYPE && tx.nUpdateType == ZelnodeUpdateType::UPDATE_CONFIRM `  . We don't want to do this check on starting zelnode transactions. 