### PR TITLE
Add height check when calling CheckUpdateHeight

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1240,7 +1240,7 @@ bool ContextualCheckTransaction(
                     strFailMessage = "zelnode-tx-invalid-update-confirm-outpoint-not-confirmed";
                 }
 
-                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx)) {
+                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx, nHeight)) {
                     fFailure = true;
                     strFailMessage = "zelnode-tx-invalid-update-confirm-outpoint-not-confirmed-or-too-soon";
                 }


### PR DESCRIPTION
- Missed this addition, this should fix the problem with pools finding invalid blocks. 