### PR TITLE
Always use the height during the check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1693,7 +1693,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
             if (pool.lookup(poolTxHash, poolTx)) {
                 if (tx.sigTime > poolTx.sigTime) {
-                    LogPrintf("Removing zelnode transaction, because it is getting replaced by newer transaction. old: %s, new: %s, collateral: %s\n", poolTx.GetHash().GetHex(), tx.GetHash().GetHex(), tx.collateralOut.ToFullString());
+                    LogPrint("zelnode", "Removing zelnode transaction, because it is getting replaced by newer transaction. old: %s, new: %s, collateral: %s\n", poolTx.GetHash().GetHex(), tx.GetHash().GetHex(), tx.collateralOut.ToFullString());
                     std::list<CTransaction> removed;
                     mempool.remove(poolTx, removed, false);
                 } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1243,7 +1243,7 @@ bool ContextualCheckTransaction(
 
                 // Check the update height, but make sure we only pass in the height if this check is coming from an AcceptBlock call
                 // If it is coming from an AcceptBlock call pass in the height of the block otherwise use the default 0
-                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx, fFromAccept || fFromMempool ? nHeight : 0)) {
+                if (!fFailure && !g_zelnodeCache.CheckUpdateHeight(tx, nHeight)) {
                     fFailure = true;
                     strFailMessage = "zelnode-tx-invalid-update-confirm-outpoint-not-confirmed-or-too-soon";
                 }


### PR DESCRIPTION
- Missed this addition, this should fix the problem with pools finding invalid blocks. 
- Moved zelnode replace transaction log to **Zelnode** category - Progress on less log spam by default