### PR TITLE
Verify checkpoint blocks, clean up errors in logs

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -232,10 +232,10 @@ public:
             (1040000, uint256S("0x00000007f3b465bd4b0e161e43c05a3d946144330e33ea3a91cb952e6ef86b7d"))
             (1040577, uint256S("0x000000071fe89682ac260bc0a49621344eb28ae01659c9e7ce86e3762e45f52d"))
             (1042126, uint256S("0x0000000295e4663178fd9e533787e74206645910a2bfb61938db5f67796eaad0")),
-            1581212778,     // * UNIX timestamp of last checkpoint block
-            1429455,              // * total number of transactions between genesis and last checkpoint
+            1643039394,     // * UNIX timestamp of last checkpoint block
+            16728243,              // * total number of transactions between genesis and last checkpoint
                             //   (the tx=... number in the SetBestChain debug.log lines)
-            1941            // * estimated number of transactions per day
+            20065            // * estimated number of transactions per day
                             //   total number of tx / (checkpoint block height / (24 * 30))
         };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -221,7 +221,17 @@ public:
             (35000, uint256S("0x000000004646dd797644b9c67aff320961e95c311b4f26985424b720d09fcaa5"))
             (70000, uint256S("0x00000001edcf7768ed39fac55414e53a78d077b1b41fccdaf9307d7bc219626a"))
             (94071, uint256S("0x00000005ec83876bc5288badf0971ae83ac7c6a286851f7b22a75a03e73b401a")) //Halep won French Open 2018
-            (530000, uint256S("0x0000004b4459ec6904e8116d178c357b0f25a7d45c5c5836ce3714791f1ed124")),
+            (277649, uint256S("0x00000004a53f9271d05071a052b3738b46663f3335d14b6aea965a3cb70c0cc8")) // reindex - check
+            (400000, uint256S("0x000000390342f0e52443ad79b43e5d85b78bf519667aeb3aa980d76caeda0369"))
+            (530000, uint256S("0x0000004b4459ec6904e8116d178c357b0f25a7d45c5c5836ce3714791f1ed124"))
+            (600000, uint256S("0x000000dea4478401e6ab95f6d05ade810115411e95e75fab9fd94a44df4b1e1d"))
+            (700000, uint256S("0x0000000845ef03939225cc592773fd7aef54b5232fc42790c46ef6f11ee3e8d4"))
+            (800000, uint256S("0x000000451b73f495b2f6ad38bd89d15495551fc15c2078ad7af3d54d06422cc6"))
+            (900000, uint256S("0x000001e1ad2bb5e3cabb09559b6e65b871bf1d2a51bcc141ce45fc4cbd1d9cd8"))
+            (1000000, uint256S("0x0000001a80e7f30d21fb14116cd01d51e1fad8ac84cc960896f4691a57368a47"))
+            (1040000, uint256S("0x00000007f3b465bd4b0e161e43c05a3d946144330e33ea3a91cb952e6ef86b7d"))
+            (1040577, uint256S("0x000000071fe89682ac260bc0a49621344eb28ae01659c9e7ce86e3762e45f52d"))
+            (1042126, uint256S("0x0000000295e4663178fd9e533787e74206645910a2bfb61938db5f67796eaad0")),
             1581212778,     // * UNIX timestamp of last checkpoint block
             1429455,              // * total number of transactions between genesis and last checkpoint
                             //   (the tx=... number in the SetBestChain debug.log lines)

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -78,4 +78,22 @@ namespace Checkpoints {
         return NULL;
     }
 
+    bool CheckBlockAgaintCheckpoint(const CCheckpointData& data, const int& nHeight, const uint256& blockhash)
+    {
+        const MapCheckpoints& checkpoints = data.mapCheckpoints;
+
+        if (checkpoints.count(nHeight)) {
+            if (blockhash == checkpoints.at(nHeight)) {
+                // return true if checkpoint nHeight is in map and the hashes match
+                return true;
+            } else {
+                // return false if checkpoint nHeight is in map, but the hashes don't match
+                return false;
+            }
+        }
+
+        // Return true if checkpoint nHeight not in map
+        return true;
+    }
+
 } // namespace Checkpoints

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -27,6 +27,8 @@ CBlockIndex* GetLastCheckpoint(const CCheckpointData& data);
 
 double GuessVerificationProgress(const CCheckpointData& data, CBlockIndex* pindex, bool fSigchecks = true);
 
+bool CheckBlockAgaintCheckpoint(const CCheckpointData& data, const int& nHeight, const uint256& blockhash);
+
 } //namespace Checkpoints
 
 #endif // BITCOIN_CHECKPOINTS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1620,13 +1620,20 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     }
 
     if (pool.IsRecentlyEvicted(tx.GetHash())) {
-        LogPrint("mempool", "Dropping txid %s : recently evicted", tx.GetHash().ToString());
+        LogPrint("mempool", "Dropping txid %s : recently evicted\n", tx.GetHash().ToString());
         return false;
     }
 
+    // if seen in block drop tx
+    if (pool.IsRecentlySeenInBlock(tx.GetHash())) {
+        LogPrint("mempool", "Dropping txid %s : recently seen in block\n", tx.GetHash().ToString());
+        return false;
+    }
+
+
     if (tx.IsZelnodeTx()) {
         if (pool.mapSeenZelnodeTx.count(tx.GetHash())) {
-            LogPrint("mempool", "Dropping txid %s : recently seen", tx.GetHash().ToString());
+            LogPrint("mempool", "Dropping txid %s : recently seen\n", tx.GetHash().ToString());
             return false;
         }
 
@@ -3852,8 +3859,14 @@ bool static DisconnectTip(CValidationState &state, const CChainParams& chainpara
     assert(pcoinsTip->GetSaplingAnchorAt(pcoinsTip->GetBestAnchor(SAPLING), newSaplingTree));
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
+    bool check = true;
     BOOST_FOREACH(const CTransaction &tx, block.vtx) {
         SyncWithWallets(tx, NULL);
+
+        if (check && mempool.IsRecentlySeenInBlock(tx.GetHash())) {
+            check = false;
+            mempool.ClearRecentlySeenInBlock();
+        }
     }
     // Update cached incremental witnesses
     GetMainSignals().ChainTip(pindexDelete, &block, newSproutTree, newSaplingTree, false);
@@ -3968,6 +3981,9 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
     // ... and about transactions that got confirmed:
     BOOST_FOREACH(const CTransaction &tx, pblock->vtx) {
         SyncWithWallets(tx, pblock);
+        if (tx.IsZelnodeTx()) {
+            mempool.AddRecentlySeenInBlock(tx.GetHash());
+        }
     }
     // Update cached incremental witnesses
     GetMainSignals().ChainTip(pindexNew, pblock, oldSproutTree, oldSaplingTree, true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3212,7 +3212,13 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             // This block is an ancestor of a checkpoint: disable script checks
             fExpensiveChecks = false;
         }
+
+        if (!Checkpoints::CheckBlockAgaintCheckpoint(chainparams.Checkpoints(), pindex->nHeight, block.GetHash())) {
+            error("Failed CheckBlockAgaintCheckpoint call - %d - %s", pindex->nHeight, block.GetHash().GetHex());
+            return false;
+        }
     }
+
 
     auto verifier = libzelcash::ProofVerifier::Strict();
     auto disabledVerifier = libzelcash::ProofVerifier::Disabled();
@@ -4715,8 +4721,14 @@ bool ContextualCheckBlockHeader(
     {
         // Don't accept any forks from the main chain prior to last checkpoint
         CBlockIndex* pcheckpoint = Checkpoints::GetLastCheckpoint(chainParams.Checkpoints());
-        if (pcheckpoint && nHeight < pcheckpoint->nHeight)
+        if (pcheckpoint && nHeight < pcheckpoint->nHeight) {
             return state.DoS(100, error("%s: forked chain older than last checkpoint (height %d)", __func__, nHeight));
+        }
+
+        if (!Checkpoints::CheckBlockAgaintCheckpoint(chainParams.Checkpoints(), nHeight, block.GetHash())) {
+            error("Failed CheckBlockAgaintCheckpoint call in func=%s - nheight=%d - blockhash=%s", __func__, nHeight, block.GetHash().GetHex());
+            return state.DoS(0, error("%s: tried to connect to known forked chain (height %d)", __func__, nHeight));
+        }
     }
 
     // Reject block.nVersion < 4 blocks

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -855,6 +855,23 @@ bool CTxMemPool::IsRecentlyEvicted(const uint256& txId) {
     return recentlyEvicted->contains(txId);
 }
 
+void CTxMemPool::ClearRecentlySeenInBlock()
+{
+    LOCK(cs);
+    delete recentlySeenInBlock;
+    recentlySeenInBlock =  new RecentlyEvictedList(DEFAULT_MEMPOOL_EVICTION_MEMORY_MINUTES * 60 * 3);
+}
+
+bool CTxMemPool::IsRecentlySeenInBlock(const uint256& txId) {
+    LOCK(cs);
+    return recentlySeenInBlock->contains(txId);
+}
+
+void CTxMemPool::AddRecentlySeenInBlock(const uint256& txId) {
+    LOCK(cs);
+    recentlySeenInBlock->add(txId);
+}
+
 void CTxMemPool::EnsureSizeLimit() {
     AssertLockHeld(cs);
     boost::optional<uint256> maybeDropTxId;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -70,6 +70,7 @@ CTxMemPool::~CTxMemPool()
 {
     delete minerPolicyEstimator;
     delete recentlyEvicted;
+    delete recentlySeenInBlock;
     delete weightedTxTree;
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -143,6 +143,9 @@ private:
     RecentlyEvictedList* recentlyEvicted = new RecentlyEvictedList(DEFAULT_MEMPOOL_EVICTION_MEMORY_MINUTES * 60);
     WeightedTxTree* weightedTxTree = new WeightedTxTree(DEFAULT_MEMPOOL_TOTAL_COST_LIMIT);
 
+    //List for seen in block txes
+    RecentlyEvictedList* recentlySeenInBlock = new RecentlyEvictedList(DEFAULT_MEMPOOL_EVICTION_MEMORY_MINUTES * 60 * 3);
+
     void checkNullifiers(ShieldedType type) const;
     
 public:
@@ -270,6 +273,12 @@ public:
     void SetMempoolCostLimit(int64_t totalCostLimit, int64_t evictionMemorySeconds);
     // Returns true if a transaction has been recently evicted
     bool IsRecentlyEvicted(const uint256& txId);
+    // Returns true if a transaction has been recently seen in a block (ZelnodeTx)
+    bool IsRecentlySeenInBlock(const uint256& txId);
+    // Add txid to recently seen list (ZelnodeTx)
+    void AddRecentlySeenInBlock(const uint256& txId);
+    // Clear the recently seen in block list (ZelnodeTx)
+    void ClearRecentlySeenInBlock();
     // If the mempool size limit is exceeded, this evicts transactions from the mempool until it is below capacity
     void EnsureSizeLimit();
 };


### PR DESCRIPTION
a1538a1d3779ab8c0e9612cb1ece7d818e818930 - Makes is so we don't keep checking zelnodes txes that we already received in a previous block, failing the check and throw an error to the logs.... so less errors in logs that don't help. 

1c8c8be9812f05be057a9cecfb8b4054f55d6d7e - Makes is so we actually use the checkpoints data in chainparams for validating blocks at certain heights. This change fixes reindex on nodes with messy block databases. 

7ae3580a98aca4299131b129ad859b17d48628a1 - Missed addition in destructor 

I have ran this for the following tests: 
1. Fresh sync - Successful
2. Reindex on messy block node db - Successful, Failed without 1c8c8be9812f05be057a9cecfb8b4054f55d6d7e
3. Reindex on fresh synced node - Successful - Was successful without 1c8c8be9812f05be057a9cecfb8b4054f55d6d7e

All tests made it to the tip of the longest chain. 