### PR TITLE
[RPC] sendfrom/sendmany , now works with given fromaddress

### DIFF
--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -16,6 +16,10 @@ public:
     //! If false, allows unselected inputs, but requires all selected inputs be used
     bool fAllowOtherInputs;
 
+    //! Ability to send only from a specific address
+    CTxDestination fromOnlyDest;
+    bool fFromOnlyIsSet;
+
     CCoinControl()
     {
         SetNull();
@@ -24,6 +28,8 @@ public:
     void SetNull()
     {
         destChange = CNoDestination();
+        fromOnlyDest = CNoDestination();
+        fFromOnlyIsSet = false;
         fAllowOtherInputs = false;
         setSelected.clear();
     }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -36,6 +36,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnetworksolps", 1 },
     { "sendtoaddress", 1 },
     { "sendtoaddress", 4 },
+    { "consolidateutxos", 0},
     { "settxfee", 0 },
     { "getreceivedbyaddress", 1 },
     { "getreceivedbyaccount", 1 },

--- a/src/rpc/fluxnode.cpp
+++ b/src/rpc/fluxnode.cpp
@@ -793,6 +793,7 @@ UniValue viewdeterministicfluxnodelist(const UniValue& params, bool fHelp, strin
         GetDeterministicListData(deterministicList, strFilter, (Tier)currentTier);
     }
 
+
     // Return list
     return deterministicList;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3038,6 +3038,15 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                 if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsSelected((*it).first, i))
                     continue;
 
+                if (coinControl && coinControl->fFromOnlyIsSet) {
+                    CTxDestination voutdest;
+                    if (ExtractDestination(pcoin->vout[i].scriptPubKey, voutdest)) {
+                        if (coinControl->fromOnlyDest != voutdest) {
+                            continue;
+                        }
+                    }
+                }
+
                 vCoins.emplace_back(COutput(pcoin, i, nDepth, (mine & ISMINE_SPENDABLE) != ISMINE_NO));
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2878,6 +2878,61 @@ CAmount CWallet::GetBalance() const
     return nTotal;
 }
 
+void CWallet::SelectUTXOByAddress(CCoinControl& coincontrol, CAmount& nBalance,  const std::string strFrom, const bool fBypassLocked) const
+{
+    LOCK2(cs_main, cs_wallet);
+    int nUTXOSelected = 0;
+    for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+    {
+        // Hit our maximum we want to send per tx
+        if (nUTXOSelected >= 250) {
+            break;
+        }
+
+        const CWalletTx* pcoin = &(*it).second;
+        if (pcoin->IsTrusted()) {
+            CTxDestination coindest;
+            for (int i = 0; i < pcoin->vout.size(); i++) {
+                if (IsLockedCoin(pcoin->GetHash(), i)) {
+                    continue;
+                }
+                if (ExtractDestination(pcoin->vout[i].scriptPubKey, coindest)) {
+                    if (coindest == DecodeDestination(strFrom)) {
+                        CAmount nAvailableAmount = pcoin->GetAvailableCredit(false, i);
+                        if (nAvailableAmount > 0) {
+                            coincontrol.Select(COutPoint(pcoin->GetHash(), i));
+                            nBalance += nAvailableAmount;
+                            nUTXOSelected++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void CWallet::GetUTXOCountByAddress(std::map<std::string, int>& mapUTXOCount) const
+{
+    LOCK2(cs_main, cs_wallet);
+    for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+    {
+        const CWalletTx* pcoin = &(*it).second;
+        if (pcoin->IsTrusted()) {
+            CTxDestination coindest;
+            for (int i = 0; i < pcoin->vout.size(); i++) {
+                if (IsLockedCoin(pcoin->GetHash(), i)) {
+                    continue;
+                }
+                if (ExtractDestination(pcoin->vout[i].scriptPubKey, coindest)) {
+                    if (pcoin->GetAvailableCredit(false, i) > 0) {
+                        mapUTXOCount[EncodeDestination(coindest)]++;
+                    }
+                }
+            }
+        }
+    }
+}
+
 CAmount CWallet::GetUnconfirmedBalance() const
 {
     CAmount nTotal = 0;
@@ -3203,41 +3258,13 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int
 bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet,  bool& fOnlyCoinbaseCoinsRet, bool& fNeedCoinbaseCoinsRet, const CCoinControl* coinControl) const
 {
     // Output parameter fOnlyCoinbaseCoinsRet is set to true when the only available coins are coinbase utxos.
-    vector<COutput> vCoinsNoCoinbase, vCoinsWithCoinbase;
-    AvailableCoins(vCoinsNoCoinbase, true, coinControl, false, false);
+    vector<COutput> vCoinsWithCoinbase;
     AvailableCoins(vCoinsWithCoinbase, true, coinControl, false, true);
-    fOnlyCoinbaseCoinsRet = vCoinsNoCoinbase.size() == 0 && vCoinsWithCoinbase.size() > 0;
-
-    // If coinbase utxos can only be sent to zaddrs, exclude any coinbase utxos from coin selection.
-    bool fluxRebrandActive = NetworkUpgradeActive(chainActive.Height(), Params().GetConsensus(), Consensus::UPGRADE_FLUX);
-    bool fProtectCoinbase = Params().GetConsensus().fCoinbaseMustBeProtected && !fluxRebrandActive;
-    vector<COutput> vCoins = (fProtectCoinbase) ? vCoinsNoCoinbase : vCoinsWithCoinbase;
-
-    // Output parameter fNeedCoinbaseCoinsRet is set to true if coinbase utxos need to be spent to meet target amount
-    if (fProtectCoinbase && vCoinsWithCoinbase.size() > vCoinsNoCoinbase.size()) {
-        CAmount value = 0;
-        for (const COutput& out : vCoinsNoCoinbase) {
-            if (!out.fSpendable) {
-                continue;
-            }
-            value += out.tx->vout[out.i].nValue;
-        }
-        if (value <= nTargetValue) {
-            CAmount valueWithCoinbase = 0;
-            for (const COutput& out : vCoinsWithCoinbase) {
-                if (!out.fSpendable) {
-                    continue;
-                }
-                valueWithCoinbase += out.tx->vout[out.i].nValue;
-            }
-            fNeedCoinbaseCoinsRet = (valueWithCoinbase >= nTargetValue);
-        }
-    }
 
     // coin control -> return all selected outputs (we want all selected to go into the transaction for sure)
     if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs)
     {
-        BOOST_FOREACH(const COutput& out, vCoins)
+        BOOST_FOREACH(const COutput& out, vCoinsWithCoinbase)
         {
             if (!out.fSpendable)
                  continue;
@@ -3270,18 +3297,18 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTx*
     }
 
     // remove preset inputs from vCoins
-    for (vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end() && coinControl && coinControl->HasSelected();)
+    for (vector<COutput>::iterator it = vCoinsWithCoinbase.begin(); it != vCoinsWithCoinbase.end() && coinControl && coinControl->HasSelected();)
     {
         if (setPresetCoins.count(make_pair(it->tx, it->i)))
-            it = vCoins.erase(it);
+            it = vCoinsWithCoinbase.erase(it);
         else
             ++it;
     }
 
     bool res = nTargetValue <= nValueFromPresetInputs ||
-        SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, 1, 6, vCoins, setCoinsRet, nValueRet) ||
-        SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, 1, 1, vCoins, setCoinsRet, nValueRet) ||
-        (bSpendZeroConfChange && SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, 0, 1, vCoins, setCoinsRet, nValueRet));
+        SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, 1, 6, vCoinsWithCoinbase, setCoinsRet, nValueRet) ||
+        SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, 1, 1, vCoinsWithCoinbase, setCoinsRet, nValueRet) ||
+        (bSpendZeroConfChange && SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, 0, 1, vCoinsWithCoinbase, setCoinsRet, nValueRet));
 
     // because SelectCoinsMinConf clears the setCoinsRet, we now add the possible inputs to the coinset
     setCoinsRet.insert(setPresetCoins.begin(), setPresetCoins.end());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2695,7 +2695,7 @@ CAmount CWalletTx::GetImmatureCredit(bool fUseCache) const
     return 0;
 }
 
-CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const
+CAmount CWalletTx::GetAvailableCredit(bool fUseCache, int index) const
 {
     if (pwallet == 0)
         return 0;
@@ -2711,6 +2711,13 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const
     uint256 hashTx = GetHash();
     for (unsigned int i = 0; i < vout.size(); i++)
     {
+
+        if (index > -1) {
+            if (index != i){
+                continue;
+            }
+        }
+
         if (!pwallet->IsSpent(hashTx, i))
         {
             const CTxOut &txout = vout[i];

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -567,7 +567,7 @@ public:
     CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
-    CAmount GetAvailableCredit(bool fUseCache=true) const;
+    CAmount GetAvailableCredit(bool fUseCache=true, int index=-1) const;
     CAmount GetImmatureWatchOnlyCredit(const bool& fUseCache=true) const;
     CAmount GetAvailableWatchOnlyCredit(const bool& fUseCache=true) const;
     CAmount GetChange() const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1143,6 +1143,8 @@ public:
     CAmount GetWatchOnlyBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
+    void GetUTXOCountByAddress(std::map<std::string, int> & mapUTXOCount) const;
+    void SelectUTXOByAddress(CCoinControl& coincontrol, CAmount& nBalance, const std::string strFrom, const bool fBypassLocked) const;
     bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosRet, std::string& strFailReason);
     bool CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosRet,
                            std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1137,7 +1137,7 @@ public:
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime);
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime);
-    CAmount GetBalance() const;
+    CAmount GetBalance(const std::string strFrom = "") const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
     CAmount GetWatchOnlyBalance() const;


### PR DESCRIPTION
Fixes #94 

Added ability to use the **sendfrom** rpc call and pass in a fromaddress - Flux will only be sent from the fromaddress, and all change will be sent back to this address also - This call was marked as deprecated as it used to use accounts. However, I don't see any reason why we shouldn't allow users to specific a fromaddress if they would like. 

Added ability to use the **sendmany** rpc call and pass in a fromaddress - Flux will only be sent from the fromaddress, and all change will be sent back to this address also.

Added new rpc **consolidateutxos** which will try and take utxo's from a single address, and send them back to the same address in a single utxo
