### PR TITLE
Add P2SH fluxnode for supports public/private key pairs

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -267,6 +267,10 @@ public:
         nBeginStratusTransition = 999999999;
         nEndStratusTransition = 999999999;
 
+        vecP2SHPublicKeys.resize(1);
+        vecP2SHPublicKeys[0] = std::make_pair("042d8ac337d0e5dc9ee0fdf4cb9c36970b10e59a6d50ce2c4dea5a18bc428707fdf1e4b7fe7743302af902d7002e0bd324cbd8030daa478677c6c8a3b807066909", 0);
+
+
         // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring
         // in #2795.
@@ -435,6 +439,8 @@ public:
         nBeginStratusTransition = 26000;
         nEndStratusTransition = 32000;
 
+        vecP2SHPublicKeys.resize(1);
+        vecP2SHPublicKeys[0] = std::make_pair("04276f105ff36a670a56e75c2462cff05a4a7864756e6e1af01022e32752d6fe57b1e13cab4f2dbe3a6a51b4e0de83a5c4627345f5232151867850018c9a3c3a1d", 0);
 
     // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring
@@ -598,6 +604,10 @@ public:
 
         nBeginStratusTransition = 999999999;
         nEndStratusTransition = 999999999;
+
+        vecP2SHPublicKeys.resize(1);
+        vecP2SHPublicKeys[0] = std::make_pair("04276f105ff36a670a56e75c2462cff05a4a7864756e6e1af01022e32752d6fe57b1e13cab4f2dbe3a6a51b4e0de83a5c4627345f5232151867850018c9a3c3a1d", 0);
+
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -136,7 +136,7 @@ public:
                 uint256S("000000ce99aa6765bdaae673cdf41f661ff20a116eb6f2fe0843488d8061f193");
 
         consensus.vUpgrades[Consensus::UPGRADE_HALVING].nProtocolVersion = 170018;
-        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 999999999;
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 1097412;
 
 
         consensus.nZawyLWMAAveragingWindow = 60;
@@ -211,10 +211,10 @@ public:
         nStartZelnodePaymentsHeight = 560000; // Start paying deterministic zelnodes on height
 
         // These are the benchmarking public keys, if you are adding a key, you must increase the resize integer
-        vecBenchmarkingPublicKeys.resize(2);
+        vecBenchmarkingPublicKeys.resize(3);
         vecBenchmarkingPublicKeys[0] = std::make_pair("042e79d7dd1483996157df6b16c831be2b14b31c69944ea2a585c63b5101af1f9517ba392cee5b1f45a62e9d936488429374535a2f76870bfa8eea6667b13eb39e", 0);
         vecBenchmarkingPublicKeys[1] = std::make_pair("04517413e51fa9b2e94f200b254cca69beb86f2d74bf66ca53854ba66bc376dde9b52e9b4403731d9a4f3e8edd9687f1e1824b688fe26454bd9fb823a3307b4682", 1618113600); // Sun Apr 11 2021 04:00:00 UTC
-
+        vecBenchmarkingPublicKeys[2] = std::make_pair("0480dff65aa9d4b4c4234e4723a5e7c5bf527ca683b53aa26a7225cc5eb16e6e79f9629eb5f96c12b173de7a20e9823b2d36575759f3490864922f7ed04e171fad", 1649682000); // Mon Apr 11 2022 13:00:00 UTC
         assert(vecBenchmarkingPublicKeys.size() > 0);
 
 
@@ -235,11 +235,12 @@ public:
             (1000000, uint256S("0x0000001a80e7f30d21fb14116cd01d51e1fad8ac84cc960896f4691a57368a47"))
             (1040000, uint256S("0x00000007f3b465bd4b0e161e43c05a3d946144330e33ea3a91cb952e6ef86b7d"))
             (1040577, uint256S("0x000000071fe89682ac260bc0a49621344eb28ae01659c9e7ce86e3762e45f52d"))
-            (1042126, uint256S("0x0000000295e4663178fd9e533787e74206645910a2bfb61938db5f67796eaad0")),
-            1643039394,     // * UNIX timestamp of last checkpoint block
-            16728243,              // * total number of transactions between genesis and last checkpoint
+            (1042126, uint256S("0x0000000295e4663178fd9e533787e74206645910a2bfb61938db5f67796eaad0"))
+            (1060000, uint256S("0x0000000fd721d8d381c4b24a4f78fc036955d7a0f98d2765b8c7badad8b66c1b")),
+            1645201099,     // * UNIX timestamp of last checkpoint block
+            17772234,              // * total number of transactions between genesis and last checkpoint
                             //   (the tx=... number in the SetBestChain debug.log lines)
-            20065            // * estimated number of transactions per day
+            24683            // * estimated number of transactions per day
                             //   total number of tx / (checkpoint block height / (24 * 30))
         };
 
@@ -258,18 +259,18 @@ public:
         nSwapPoolInterval = 21600; // Avg Block per day (720) *  - Trying to get to around once a month
         nSwapPoolMaxTimes = 10;
 
-        nBeginCumulusTransition = 999999999;
-        nEndCumulusTransition = 999999999;
+        nBeginCumulusTransition = 1076532;
+        nEndCumulusTransition = 1086612;
 
-        nBeginNimbusTransition = 999999999;
-        nEndNimbusTransition = 999999999;
+        nBeginNimbusTransition = 1081572;
+        nEndNimbusTransition = 1092372;
 
-        nBeginStratusTransition = 999999999;
-        nEndStratusTransition = 999999999;
+        nBeginStratusTransition = 1087332;
+        nEndStratusTransition = 1097412;
 
         vecP2SHPublicKeys.resize(1);
-        vecP2SHPublicKeys[0] = std::make_pair("042d8ac337d0e5dc9ee0fdf4cb9c36970b10e59a6d50ce2c4dea5a18bc428707fdf1e4b7fe7743302af902d7002e0bd324cbd8030daa478677c6c8a3b807066909", 0);
-
+        vecP2SHPublicKeys[0] = std::make_pair("04ab11edbb8a15f7cc2628a4a2c18cea095d250f8c9a2924cbd581b8d8fb3a8b91e39e5febddb7ffc60f20dfd352a40aa4f061aa60a9ace26d43e1b7a18aea4162", 0);
+        assert(vecP2SHPublicKeys.size() > 0);
 
         // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -154,6 +154,9 @@ public:
     int GetStratusEndTransitionHeight() const { return nEndStratusTransition; }
 
 
+    std::vector<std::pair<std::string, uint32_t> > GetP2SHFluxnodePublicKeys() const { return vecP2SHPublicKeys; }
+
+
 protected:
     CChainParams() {}
 
@@ -217,6 +220,9 @@ protected:
     int64_t nEndNimbusTransition;
     int64_t nBeginStratusTransition;
     int64_t nEndStratusTransition;
+
+
+    std::vector< std::pair<std::string, uint32_t> > vecP2SHPublicKeys;
 };
 
 /**

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -812,5 +812,30 @@ bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey) {
 
     return false;
 }
+
+bool GetFluxNodeP2SHDestination(const CCoinsViewCache* coinsCache, const COutPoint& outpoint, CTxDestination& destination) {
+    // Get the scriptpubkey and build the destination from it
+    CCoins coins;
+
+    if (!coinsCache->GetCoins(outpoint.hash, coins)) {
+        error("Failing to retreive coins -- for outpoint %s --- %s - %d", outpoint.ToFullString(), __func__, __LINE__);
+        return false;
+    }
+
+    CTxDestination dest;
+    if (coins.IsAvailable(outpoint.n)) {
+        if (!ExtractDestination(coins.vout[outpoint.n].scriptPubKey, dest)) {
+            error("Failing to extract destination -- for outpoint %s --- %s - %d", outpoint.ToFullString(), __func__, __LINE__);
+            return false;
+        }
+    } else {
+        // Coin is spent
+        error("Coin not available -- for outpoint %s --- %s - %d", outpoint.ToFullString(), __func__, __LINE__);
+        return false;
+    }
+
+    destination = dest;
+    return true;
+}
 /** Coins Tier code end **/
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -646,6 +646,14 @@ bool CCoinsViewCache::CheckZelnodeTxInput(const CTransaction& tx, const int& p_H
         return false;
     }
 
+    if (IsAP2SHFluxNodePublicKey(tx.collateralPubkey)) {
+        bool fHalvingActive = NetworkUpgradeActive(p_Height, Params().GetConsensus(), Consensus::UPGRADE_HALVING);
+        if (!fHalvingActive) {
+            error("Using P2SH collateral key before it is actives");
+            return false;
+        }
+    }
+
     nCollateralAmount = coins->vout[prevout.n].nValue;
 
     return IsCoinTierValid(nTier);
@@ -787,6 +795,22 @@ bool GetCoinTierPercentage(const int& nTier, double& p_double)
 bool IsCoinTierValid(const int& nTier)
 {
     return nTier > NONE && nTier < LAST;
+}
+
+bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey) {
+    // Get the public keys and timestamps from the chainparams
+    std::vector<std::pair<std::string, uint32_t> > vectorPublicKeys = Params().GetP2SHFluxnodePublicKeys();
+
+    for (int i = 0; i < vectorPublicKeys.size(); i++) {
+        std::string public_key = vectorPublicKeys[i].first;
+        CPubKey chainpubkey(ParseHex(public_key));
+
+        if (chainpubkey == pubkey) {
+            return true;
+        }
+    }
+
+    return false;
 }
 /** Coins Tier code end **/
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -11,6 +11,7 @@
 #include "memusage.h"
 #include "serialize.h"
 #include "uint256.h"
+#include "script/standard.h"
 
 #include <assert.h>
 #include <stdint.h>
@@ -598,6 +599,7 @@ bool GetCoinTierFromAmount(const int& p_Height, const CAmount& nAmount, int& nTi
 bool GetCoinTierPercentage(const int& nTier, double& p_float);
 bool IsCoinTierValid(const int& nTier);
 bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey);
+bool GetFluxNodeP2SHDestination(const CCoinsViewCache* coinsCache, const COutPoint& outpoint, CTxDestination& destination);
 
 std::set<CAmount> GetCoinAmountsByTier(const int& p_Height, const int& nTier);
 /** Coins Tier code end **/

--- a/src/coins.h
+++ b/src/coins.h
@@ -597,6 +597,7 @@ void InitializeCoinTierAmounts();
 bool GetCoinTierFromAmount(const int& p_Height, const CAmount& nAmount, int& nTier);
 bool GetCoinTierPercentage(const int& nTier, double& p_float);
 bool IsCoinTierValid(const int& nTier);
+bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey);
 
 std::set<CAmount> GetCoinAmountsByTier(const int& p_Height, const int& nTier);
 /** Coins Tier code end **/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1181,9 +1181,22 @@ bool ContextualCheckTransaction(
                     strFailMessage = "zelnode-tx-failed-to-extract-destination";
                 }
 
-                if (!fFailure && EncodeDestination(destination) != EncodeDestination(userpubkey.GetID())) {
-                    fFailure = true;
-                    strFailMessage = "zelnode-tx-destinations-didn't-match";
+                if (coins.vout[outPoint.n].scriptPubKey.IsPayToScriptHash()) {
+                    // Here we have a node of which the collatoral is stored in a multisig address.
+                    // Only the flux foundation can do this. So lets use the chainparams public key to verify the signature
+                    // This means that the userpubkey is unable to be the same as the destination
+                    std::string public_key = GetP2SHFluxNodePublicKey(tx);
+                    CPubKey pubkey(ParseHex(public_key));
+
+                    if (tx.collateralPubkey != pubkey) {
+                        fFailure = true;
+                        strFailMessage = "zelnode-tx-p2sh-publickeys-didn't-match";
+                    }
+                } else {
+                    if (!fFailure && EncodeDestination(destination) != EncodeDestination(userpubkey.GetID())) {
+                        fFailure = true;
+                        strFailMessage = "zelnode-tx-destinations-didn't-match";
+                    }
                 }
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6635,6 +6635,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
     else if (strCommand == "tx")
     {
+        if (IsInitialBlockDownload(Params())) {
+            return false;
+        }
+
         vector<uint256> vWorkQueue;
         vector<uint256> vEraseQueue;
         CTransaction tx;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6485,7 +6485,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             bool fAlreadyHave = AlreadyHave(inv);
             LogPrint("net", "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom->id);
 
-            if (!fAlreadyHave && !fImporting && !fReindex && inv.type != MSG_BLOCK)
+            if (!fAlreadyHave && !fImporting && !fReindex && inv.type != MSG_BLOCK && !IsInitialBlockDownload(Params()))
                 pfrom->AskFor(inv);
 
             if (inv.type == MSG_BLOCK) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1175,13 +1175,18 @@ bool ContextualCheckTransaction(
                     strFailMessage = "zelnode-tx-coins-not-found";
                 }
 
+                if (!fFailure && !coins.IsAvailable(outPoint.n)) {
+                    fFailure = true;
+                    strFailMessage = "zelnode-tx-coins-not-available";
+                }
+
                 CTxDestination destination;
                 if (!fFailure && !ExtractDestination(coins.vout[outPoint.n].scriptPubKey, destination)) {
                     fFailure = true;
                     strFailMessage = "zelnode-tx-failed-to-extract-destination";
                 }
 
-                if (coins.vout[outPoint.n].scriptPubKey.IsPayToScriptHash()) {
+                if (!fFailure && coins.vout[outPoint.n].scriptPubKey.IsPayToScriptHash()) {
                     // Here we have a node of which the collatoral is stored in a multisig address.
                     // Only the flux foundation can do this. So lets use the chainparams public key to verify the signature
                     // This means that the userpubkey is unable to be the same as the destination

--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -648,8 +648,17 @@ void GetDeterministicListData(UniValue& listData, const std::string& strFilter, 
         if (!data.IsNull()) {
             std::string strTxHash = data.collateralIn.GetTxHash();
 
+
+            CTxDestination payment_destination;
+            if (IsAP2SHFluxNodePublicKey(data.collateralPubkey)) {
+                GetFluxNodeP2SHDestination(pcoinsTip, data.collateralIn, payment_destination);
+            } else {
+                payment_destination = data.collateralPubkey.GetID();
+            }
+
+
             if (strFilter != "" && strTxHash.find(strFilter) == string::npos && HexStr(data.pubKey).find(strFilter) &&
-                data.ip.find(strFilter) && EncodeDestination(data.collateralPubkey.GetID()).find(strFilter) == string::npos)
+                data.ip.find(strFilter) && EncodeDestination(payment_destination).find(strFilter) == string::npos)
                 continue;
 
             std::string strHost = data.ip;
@@ -666,7 +675,7 @@ void GetDeterministicListData(UniValue& listData, const std::string& strFilter, 
             info.push_back(std::make_pair("last_confirmed_height", data.nLastConfirmedBlockHeight));
             info.push_back(std::make_pair("last_paid_height", data.nLastPaidHeight));
             info.push_back(std::make_pair("tier", data.TierToString()));
-            info.push_back(std::make_pair("payment_address", EncodeDestination(data.collateralPubkey.GetID())));
+            info.push_back(std::make_pair("payment_address", EncodeDestination(payment_destination)));
             info.push_back(std::make_pair("pubkey", HexStr(data.pubKey)));
             if (chainActive.Height() >= data.nAddedBlockHeight)
                 info.push_back(std::make_pair("activesince", std::to_string(chainActive[data.nAddedBlockHeight]->nTime)));
@@ -777,11 +786,18 @@ UniValue getdoslist(const UniValue& params, bool fHelp)
             // Get the data from the item in the map of dox tracking
             const ZelnodeCacheData data = item.second;
 
+            CTxDestination payment_destination;
+            if (IsAP2SHFluxNodePublicKey(data.collateralPubkey)) {
+                GetFluxNodeP2SHDestination(pcoinsTip, data.collateralIn, payment_destination);
+            } else {
+                payment_destination = data.collateralPubkey.GetID();
+            }
+
             UniValue info(UniValue::VOBJ);
 
             info.push_back(std::make_pair("collateral", data.collateralIn.ToFullString()));
             info.push_back(std::make_pair("added_height", data.nAddedBlockHeight));
-            info.push_back(std::make_pair("payment_address", EncodeDestination(data.collateralPubkey.GetID())));
+            info.push_back(std::make_pair("payment_address", EncodeDestination(payment_destination)));
 
             int nCurrentHeight = chainActive.Height();
             int nEligibleIn = ZELNODE_DOS_REMOVE_AMOUNT - (nCurrentHeight - data.nAddedBlockHeight);
@@ -841,11 +857,18 @@ UniValue getstartlist(const UniValue& params, bool fHelp)
             // Get the data from the item in the map of dox tracking
             const ZelnodeCacheData data = item.second;
 
+            CTxDestination payment_destination;
+            if (IsAP2SHFluxNodePublicKey(data.collateralPubkey)) {
+                GetFluxNodeP2SHDestination(pcoinsTip, data.collateralIn, payment_destination);
+            } else {
+                payment_destination = data.collateralPubkey.GetID();
+            }
+
             UniValue info(UniValue::VOBJ);
 
             info.push_back(std::make_pair("collateral", data.collateralIn.ToFullString()));
             info.push_back(std::make_pair("added_height", data.nAddedBlockHeight));
-            info.push_back(std::make_pair("payment_address", EncodeDestination(data.collateralPubkey.GetID())));
+            info.push_back(std::make_pair("payment_address", EncodeDestination(payment_destination)));
 
             int nCurrentHeight = chainActive.Height();
             int nExpiresIn = ZELNODE_START_TX_EXPIRATION_HEIGHT - (nCurrentHeight - data.nAddedBlockHeight);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3022,8 +3022,11 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                 if (IsSpent(wtxid, i))
                     continue;
 
-                if (mine == ISMINE_NO)
-                    continue;
+                if (mine == ISMINE_NO) {
+                    if (!pcoin->vout[i].scriptPubKey.IsPayToScriptHash()) {
+                        continue;
+                    }
+                }
 
                 if (IsLockedCoin((*it).first, i) && nCoinType != ONLY_CUMULUS && nCoinType != ONLY_NIMBUS && nCoinType != ONLY_STRATUS && nCoinType != ALL_ZELNODE )
                     continue;
@@ -4862,6 +4865,14 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubK
 
     CTxDestination address1;
     ExtractDestination(pubScript, address1);
+
+    if (pubScript.IsPayToScriptHash()) {
+        if (!GetKeysForP2SHFluxNode(pubKeyRet, keyRet)) {
+            LogPrintf("%s-- Failed to get P2SH keys\n", __func__);
+            return false;
+        }
+        return true;
+    }
 
     CKeyID* keyID;
     keyID = boost::get<CKeyID>(&address1);

--- a/src/zelnode/activezelnode.cpp
+++ b/src/zelnode/activezelnode.cpp
@@ -152,6 +152,14 @@ bool ActiveZelnode::GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubkey, C
     CTxDestination address1;
     ExtractDestination(pubScript, address1);
 
+    if (pubScript.IsPayToScriptHash()) {
+        if (!GetKeysForP2SHFluxNode(pubkey, secretKey)) {
+            LogPrintf("%s-- Failed to get P2SH keys\n", __func__);
+            return false;
+        }
+        return true;
+    }
+
     CKeyID* keyid;
     keyid = boost::get<CKeyID>(&address1);
 

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -501,8 +501,14 @@ bool ZelnodeCache::GetNextPayment(CTxDestination& dest, const int nTier, COutPoi
                             }
 
                             CTxDestination destination;
-                            if (!ExtractDestination(coins.vout[p_zelnodeOut.n].scriptPubKey, destination)) {
-                                error("Failing to extract destination ----- %s - %d", __func__, __LINE__);
+                            if (coins.IsAvailable(p_zelnodeOut.n)) {
+                                if (!ExtractDestination(coins.vout[p_zelnodeOut.n].scriptPubKey, destination)) {
+                                    error("Failing to extract destination ----- %s - %d", __func__, __LINE__);
+                                    return false;
+                                }
+                            } else {
+                                // Coin is spent
+                                error("Coin not available ----- %s - %d", __func__, __LINE__);
                                 return false;
                             }
 

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -438,6 +438,7 @@ public:
 
 int GetZelnodeExpirationCount(const int& p_nHeight);
 std::string GetZelnodeBenchmarkPublicKey(const CTransaction& tx);
+std::string GetP2SHFluxNodePublicKey(const uint32_t& nSigTime);
 std::string GetP2SHFluxNodePublicKey(const CTransaction& tx);
 bool GetKeysForP2SHFluxNode(CPubKey& pubKeyRet, CKey& keyRet);
 

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -438,6 +438,8 @@ public:
 
 int GetZelnodeExpirationCount(const int& p_nHeight);
 std::string GetZelnodeBenchmarkPublicKey(const CTransaction& tx);
+std::string GetP2SHFluxNodePublicKey(const CTransaction& tx);
+bool GetKeysForP2SHFluxNode(CPubKey& pubKeyRet, CKey& keyRet);
 
 bool IsDZelnodeActive();
 bool IsZelnodeTransactionsActive();


### PR DESCRIPTION
- Halving changes
- P2SH fluxnodes
- Testnet changes included
- Version Bump
- Protocol Version Bump

- cb3cae5 -> Updated rebuildzelnodedb rpc call 
- 88b5704 -> Added required fields in chainparams for halving, and added ability to get new flux node collateral amounts
- 2fad24c -> Added enforcment checks on collateral amounts, and added new field to zelnodecachedata object
- 14d9d27 -> Added testnet chainparams block heights for halving, updated protocol version, and enfocement of node protocol version once halving starts
- b99668e -> Make sure we only expire nodes during the transition period. Save time do the task over and over once the halving has been completed
- b19d6c7 -> Increase the minimum confirmation window, and maximum confirmation window to send an update confirmation fluxnode transaction. Added helpful rpc call to get node count for migrated vs non-migrated nodes




e2c1828 - If we are in initial chain download. Stop accepting tx from peers, as some txes require chain data to verify. 
`2022-02-16 20:29:16 ERROR: zelnode-tx-coins-not-found
2022-02-16 20:29:16 ERROR: AcceptToMemoryPool: ContextualCheckTransaction failed
2022-02-16 20:29:16 Misbehaving: **.***.40.230:16125 (20 -> 30)
`
