### PR TITLE
[Halving] Fluxnode halving, bug fixes, p2sh fluxnode, increase confirm reqs

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -254,6 +254,13 @@ public:
         nSwapPoolInterval = 21600; // Avg Block per day (720) *  - Trying to get to around once a month
         nSwapPoolMaxTimes = 10;
 
+        nBeginCumulusTransition = 999999999;
+        nEndCumulusTransition = 999999999;
+        nBeginNimbusTransition = 999999999;
+        nEndNimbusTransition = 999999999;
+        nBeginStratusTransition = 999999999;
+        nEndStratusTransition = 999999999;
+
         // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring
         // in #2795.
@@ -410,6 +417,14 @@ public:
         nSwapPoolInterval = 100;
         nSwapPoolMaxTimes = 10;
 
+        nBeginCumulusTransition = 9999999999;
+        nEndCumulusTransition = 9999999999;
+        nBeginNimbusTransition = 9999999999;
+        nEndNimbusTransition = 9999999999;
+        nBeginStratusTransition = 9999999999;
+        nEndStratusTransition = 9999999999;
+
+
     // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring
         // in #2795.
@@ -559,6 +574,13 @@ public:
         nSwapPoolAmount = 2100000 * COIN;
         nSwapPoolInterval = 10;
         nSwapPoolMaxTimes = 5;
+
+        nBeginCumulusTransition = 9999999999;
+        nEndCumulusTransition = 9999999999;
+        nBeginNimbusTransition = 9999999999;
+        nEndNimbusTransition = 9999999999;
+        nBeginStratusTransition = 9999999999;
+        nEndStratusTransition = 9999999999;
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -267,6 +267,10 @@ public:
         nBeginStratusTransition = 999999999;
         nEndStratusTransition = 999999999;
 
+        vecP2SHPublicKeys.resize(1);
+        vecP2SHPublicKeys[0] = std::make_pair("042d8ac337d0e5dc9ee0fdf4cb9c36970b10e59a6d50ce2c4dea5a18bc428707fdf1e4b7fe7743302af902d7002e0bd324cbd8030daa478677c6c8a3b807066909", 0);
+
+
         // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring
         // in #2795.
@@ -435,6 +439,8 @@ public:
         nBeginStratusTransition = 26000;
         nEndStratusTransition = 32000;
 
+        vecP2SHPublicKeys.resize(1);
+        vecP2SHPublicKeys[0] = std::make_pair("04276f105ff36a670a56e75c2462cff05a4a7864756e6e1af01022e32752d6fe57b1e13cab4f2dbe3a6a51b4e0de83a5c4627345f5232151867850018c9a3c3a1d", 0);
 
     // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring
@@ -598,6 +604,10 @@ public:
 
         nBeginStratusTransition = 999999999;
         nEndStratusTransition = 999999999;
+
+        vecP2SHPublicKeys.resize(1);
+        vecP2SHPublicKeys[0] = std::make_pair("04276f105ff36a670a56e75c2462cff05a4a7864756e6e1af01022e32752d6fe57b1e13cab4f2dbe3a6a51b4e0de83a5c4627345f5232151867850018c9a3c3a1d", 0);
+
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -136,7 +136,7 @@ public:
                 uint256S("000000ce99aa6765bdaae673cdf41f661ff20a116eb6f2fe0843488d8061f193");
 
         consensus.vUpgrades[Consensus::UPGRADE_HALVING].nProtocolVersion = 170018;
-        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 1097412;
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 1076532; // Around March 12 2022
 
 
         consensus.nZawyLWMAAveragingWindow = 60;
@@ -214,7 +214,7 @@ public:
         vecBenchmarkingPublicKeys.resize(3);
         vecBenchmarkingPublicKeys[0] = std::make_pair("042e79d7dd1483996157df6b16c831be2b14b31c69944ea2a585c63b5101af1f9517ba392cee5b1f45a62e9d936488429374535a2f76870bfa8eea6667b13eb39e", 0);
         vecBenchmarkingPublicKeys[1] = std::make_pair("04517413e51fa9b2e94f200b254cca69beb86f2d74bf66ca53854ba66bc376dde9b52e9b4403731d9a4f3e8edd9687f1e1824b688fe26454bd9fb823a3307b4682", 1618113600); // Sun Apr 11 2021 04:00:00 UTC
-        vecBenchmarkingPublicKeys[2] = std::make_pair("0480dff65aa9d4b4c4234e4723a5e7c5bf527ca683b53aa26a7225cc5eb16e6e79f9629eb5f96c12b173de7a20e9823b2d36575759f3490864922f7ed04e171fad", 1649682000); // Mon Apr 11 2022 13:00:00 UTC
+        vecBenchmarkingPublicKeys[2] = std::make_pair("0480dff65aa9d4b4c4234e4723a5e7c5bf527ca683b53aa26a7225cc5eb16e6e79f9629eb5f96c12b173de7a20e9823b2d36575759f3490864922f7ed04e171fad", 1647262800); // Mon Mar 14 2022 13:00:00 UTC
         assert(vecBenchmarkingPublicKeys.size() > 0);
 
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -136,7 +136,7 @@ public:
                 uint256S("000000ce99aa6765bdaae673cdf41f661ff20a116eb6f2fe0843488d8061f193");
 
         consensus.vUpgrades[Consensus::UPGRADE_HALVING].nProtocolVersion = 170018;
-        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 999999999;
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 1097412;
 
 
         consensus.nZawyLWMAAveragingWindow = 60;
@@ -211,10 +211,10 @@ public:
         nStartZelnodePaymentsHeight = 560000; // Start paying deterministic zelnodes on height
 
         // These are the benchmarking public keys, if you are adding a key, you must increase the resize integer
-        vecBenchmarkingPublicKeys.resize(2);
+        vecBenchmarkingPublicKeys.resize(3);
         vecBenchmarkingPublicKeys[0] = std::make_pair("042e79d7dd1483996157df6b16c831be2b14b31c69944ea2a585c63b5101af1f9517ba392cee5b1f45a62e9d936488429374535a2f76870bfa8eea6667b13eb39e", 0);
         vecBenchmarkingPublicKeys[1] = std::make_pair("04517413e51fa9b2e94f200b254cca69beb86f2d74bf66ca53854ba66bc376dde9b52e9b4403731d9a4f3e8edd9687f1e1824b688fe26454bd9fb823a3307b4682", 1618113600); // Sun Apr 11 2021 04:00:00 UTC
-
+        vecBenchmarkingPublicKeys[2] = std::make_pair("0480dff65aa9d4b4c4234e4723a5e7c5bf527ca683b53aa26a7225cc5eb16e6e79f9629eb5f96c12b173de7a20e9823b2d36575759f3490864922f7ed04e171fad", 1649682000); // Mon Apr 11 2022 13:00:00 UTC
         assert(vecBenchmarkingPublicKeys.size() > 0);
 
 
@@ -235,11 +235,12 @@ public:
             (1000000, uint256S("0x0000001a80e7f30d21fb14116cd01d51e1fad8ac84cc960896f4691a57368a47"))
             (1040000, uint256S("0x00000007f3b465bd4b0e161e43c05a3d946144330e33ea3a91cb952e6ef86b7d"))
             (1040577, uint256S("0x000000071fe89682ac260bc0a49621344eb28ae01659c9e7ce86e3762e45f52d"))
-            (1042126, uint256S("0x0000000295e4663178fd9e533787e74206645910a2bfb61938db5f67796eaad0")),
-            1643039394,     // * UNIX timestamp of last checkpoint block
-            16728243,              // * total number of transactions between genesis and last checkpoint
+            (1042126, uint256S("0x0000000295e4663178fd9e533787e74206645910a2bfb61938db5f67796eaad0"))
+            (1060000, uint256S("0x0000000fd721d8d381c4b24a4f78fc036955d7a0f98d2765b8c7badad8b66c1b")),
+            1645201099,     // * UNIX timestamp of last checkpoint block
+            17772234,              // * total number of transactions between genesis and last checkpoint
                             //   (the tx=... number in the SetBestChain debug.log lines)
-            20065            // * estimated number of transactions per day
+            24683            // * estimated number of transactions per day
                             //   total number of tx / (checkpoint block height / (24 * 30))
         };
 
@@ -258,18 +259,18 @@ public:
         nSwapPoolInterval = 21600; // Avg Block per day (720) *  - Trying to get to around once a month
         nSwapPoolMaxTimes = 10;
 
-        nBeginCumulusTransition = 999999999;
-        nEndCumulusTransition = 999999999;
+        nBeginCumulusTransition = 1076532;
+        nEndCumulusTransition = 1086612;
 
-        nBeginNimbusTransition = 999999999;
-        nEndNimbusTransition = 999999999;
+        nBeginNimbusTransition = 1081572;
+        nEndNimbusTransition = 1092372;
 
-        nBeginStratusTransition = 999999999;
-        nEndStratusTransition = 999999999;
+        nBeginStratusTransition = 1087332;
+        nEndStratusTransition = 1097412;
 
         vecP2SHPublicKeys.resize(1);
-        vecP2SHPublicKeys[0] = std::make_pair("042d8ac337d0e5dc9ee0fdf4cb9c36970b10e59a6d50ce2c4dea5a18bc428707fdf1e4b7fe7743302af902d7002e0bd324cbd8030daa478677c6c8a3b807066909", 0);
-
+        vecP2SHPublicKeys[0] = std::make_pair("04ab11edbb8a15f7cc2628a4a2c18cea095d250f8c9a2924cbd581b8d8fb3a8b91e39e5febddb7ffc60f20dfd352a40aa4f061aa60a9ace26d43e1b7a18aea4162", 0);
+        assert(vecP2SHPublicKeys.size() > 0);
 
         // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -135,6 +135,10 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].hashActivationBlock =
                 uint256S("000000ce99aa6765bdaae673cdf41f661ff20a116eb6f2fe0843488d8061f193");
 
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nProtocolVersion = 170018;
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 999999999;
+
+
         consensus.nZawyLWMAAveragingWindow = 60;
 	    consensus.eh_epoch_fade_length = 11;
 
@@ -256,8 +260,10 @@ public:
 
         nBeginCumulusTransition = 999999999;
         nEndCumulusTransition = 999999999;
+
         nBeginNimbusTransition = 999999999;
         nEndNimbusTransition = 999999999;
+
         nBeginStratusTransition = 999999999;
         nEndStratusTransition = 999999999;
 
@@ -319,7 +325,10 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_KAMATA].nActivationHeight = 350;
 
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].nProtocolVersion = 170017;
-        consensus.vUpgrades[Consensus::UPGRADE_FLUX].nActivationHeight = 420; // Around March 30 2021
+        consensus.vUpgrades[Consensus::UPGRADE_FLUX].nActivationHeight = 420;
+
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nProtocolVersion = 170018;
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight = 18000;
 
 
         consensus.nZawyLWMAAveragingWindow = 60;
@@ -417,12 +426,14 @@ public:
         nSwapPoolInterval = 100;
         nSwapPoolMaxTimes = 10;
 
-        nBeginCumulusTransition = 9999999999;
-        nEndCumulusTransition = 9999999999;
-        nBeginNimbusTransition = 9999999999;
-        nEndNimbusTransition = 9999999999;
-        nBeginStratusTransition = 9999999999;
-        nEndStratusTransition = 9999999999;
+        nBeginCumulusTransition = 18000;
+        nEndCumulusTransition = 24000;
+
+        nBeginNimbusTransition = 22000;
+        nEndNimbusTransition = 28000;
+
+        nBeginStratusTransition = 26000;
+        nEndStratusTransition = 32000;
 
 
     // Hardcoded fallback value for the Sprout shielded value pool balance
@@ -491,6 +502,10 @@ public:
 
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].nProtocolVersion = 170017;
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nProtocolVersion = 170018;
+        consensus.vUpgrades[Consensus::UPGRADE_HALVING].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
 
@@ -575,12 +590,14 @@ public:
         nSwapPoolInterval = 10;
         nSwapPoolMaxTimes = 5;
 
-        nBeginCumulusTransition = 9999999999;
-        nEndCumulusTransition = 9999999999;
-        nBeginNimbusTransition = 9999999999;
-        nEndNimbusTransition = 9999999999;
-        nBeginStratusTransition = 9999999999;
-        nEndStratusTransition = 9999999999;
+        nBeginCumulusTransition = 999999999;
+        nEndCumulusTransition = 999999999;
+
+        nBeginNimbusTransition = 999999999;
+        nEndNimbusTransition = 999999999;
+
+        nBeginStratusTransition = 999999999;
+        nEndStratusTransition = 999999999;
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -145,6 +145,15 @@ public:
     int64_t GetSwapPoolInterval() const { return nSwapPoolInterval; }
     int GetSwapPoolMaxTimes() const { return nSwapPoolMaxTimes; }
 
+
+    int GetCumulusStartTransitionHeight() const { return nBeginCumulusTransition; }
+    int GetCumulusEndTransitionHeight() const { return nEndCumulusTransition; }
+    int GetNimbusStartTransitionHeight() const { return nBeginNimbusTransition; }
+    int GetNimbusEndTransitionHeight() const { return nEndNimbusTransition; }
+    int GetStratusStartTransitionHeight() const { return nBeginStratusTransition; }
+    int GetStratusEndTransitionHeight() const { return nEndStratusTransition; }
+
+
 protected:
     CChainParams() {}
 
@@ -199,6 +208,15 @@ protected:
     int64_t nSwapPoolStartHeight;
     int64_t nSwapPoolInterval;
     int64_t nSwapPoolMaxTimes;
+
+
+    /** Flux new fluxnode start block heights **/
+    int64_t nBeginCumulusTransition;
+    int64_t nEndCumulusTransition;
+    int64_t nBeginNimbusTransition;
+    int64_t nEndNimbusTransition;
+    int64_t nBeginStratusTransition;
+    int64_t nEndStratusTransition;
 };
 
 /**

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -154,6 +154,9 @@ public:
     int GetStratusEndTransitionHeight() const { return nEndStratusTransition; }
 
 
+    std::vector<std::pair<std::string, uint32_t> > GetP2SHFluxnodePublicKeys() const { return vecP2SHPublicKeys; }
+
+
 protected:
     CChainParams() {}
 
@@ -217,6 +220,9 @@ protected:
     int64_t nEndNimbusTransition;
     int64_t nBeginStratusTransition;
     int64_t nEndStratusTransition;
+
+
+    std::vector< std::pair<std::string, uint32_t> > vecP2SHPublicKeys;
 };
 
 /**

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -624,7 +624,7 @@ bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
     return true;
 }
 
-bool CCoinsViewCache::CheckZelnodeTxInput(const CTransaction& tx, const int& p_Height, int& nTier) const
+bool CCoinsViewCache::CheckZelnodeTxInput(const CTransaction& tx, const int& p_Height, int& nTier, CAmount& nCollateralAmount) const
 {
     if (!tx.IsZelnodeTx()) {
         return false;
@@ -645,6 +645,8 @@ bool CCoinsViewCache::CheckZelnodeTxInput(const CTransaction& tx, const int& p_H
     if (!GetCoinTierFromAmount(p_Height, coins->vout[prevout.n].nValue, nTier)) {
         return false;
     }
+
+    nCollateralAmount = coins->vout[prevout.n].nValue;
 
     return IsCoinTierValid(nTier);
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -641,15 +641,10 @@ bool CCoinsViewCache::CheckZelnodeTxInput(const CTransaction& tx, const int& p_H
         return false;
     }
 
-    for (int currentTier = CUMULUS; currentTier != LAST; currentTier++) {
-        if (coins->vout[prevout.n].nValue == vCoinTierAmounts[currentTier]) {
-            nTier = currentTier;
-            return true;
-        }
-    }
-
     // Get the tier from the amount if possible
-    GetCoinTierFromAmount(coins->vout[prevout.n].nValue, nTier);
+    if (!GetCoinTierFromAmount(p_Height, coins->vout[prevout.n].nValue, nTier)) {
+        return false;
+    }
 
     return IsCoinTierValid(nTier);
 }
@@ -706,20 +701,12 @@ CCoinsModifier::~CCoinsModifier()
  * Any changes to this code needs to be also made to the code in zelnode.h and zelnode.cpp
  * We are unable to use the same code because of build/linking restrictions
  */
-std::vector<CAmount> vCoinTierAmounts;
-std::map<int, float> mapCoinTierPercentages;
+std::map<int, double> mapCoinTierPercentages;
 void InitializeCoinTierAmounts() {
     static bool fInit = false;
 
     if (fInit)
         return;
-
-    vCoinTierAmounts.clear();
-    vCoinTierAmounts.push_back(0); // NONE
-    vCoinTierAmounts.push_back(V1_ZELNODE_COLLAT_CUMULUS * COIN); // CUMULUS
-    vCoinTierAmounts.push_back(V1_ZELNODE_COLLAT_NIMBUS * COIN); // NIMBUS
-    vCoinTierAmounts.push_back(V1_ZELNODE_COLLAT_STRATUS * COIN); // STRATUS
-    vCoinTierAmounts.push_back(0); // LAST
 
     mapCoinTierPercentages[CUMULUS] = V1_ZELNODE_PERCENT_CUMULUS;
     mapCoinTierPercentages[NIMBUS] = V1_ZELNODE_PERCENT_NIMBUS;
@@ -728,22 +715,67 @@ void InitializeCoinTierAmounts() {
     fInit = true;
 }
 
-bool GetCoinTierFromAmount(const CAmount& nAmount, int& nTier)
+bool GetCoinTierFromAmount(const int& p_Height, const CAmount& nAmount, int& nTier)
 {
+    std::map<CAmount, Tier> mapTempCoinTierAmounts;
+
+    // Get correct collat amounts for all tiers
     for (int currentTier = CUMULUS; currentTier != LAST; currentTier++) {
-        if (nAmount == vCoinTierAmounts[currentTier]) {
-            nTier = currentTier;
-            return true;
+        const std::set<CAmount> setAmounts = GetCoinAmountsByTier(p_Height, currentTier);
+        for (const CAmount& amount : setAmounts) {
+            mapTempCoinTierAmounts[amount] = (Tier)currentTier;
         }
+    }
+
+    if (mapTempCoinTierAmounts.count(nAmount)) {
+        nTier = mapTempCoinTierAmounts.at(nAmount);
+        return true;
     }
 
     return false;
 }
 
-bool GetCoinTierPercentage(const int& nTier, float& p_float)
+std::set<CAmount> GetCoinAmountsByTier(const int& p_Height, const int& nTier)
+{
+    std::set<CAmount> setAmounts;
+
+    if (nTier == STRATUS) {
+        if (p_Height < Params().GetStratusStartTransitionHeight()) {
+            setAmounts.insert(V1_ZELNODE_COLLAT_STRATUS * COIN);
+        } else if (p_Height >= Params().GetStratusStartTransitionHeight() &&
+                   p_Height < Params().GetStratusEndTransitionHeight()) {
+            setAmounts.insert(V1_ZELNODE_COLLAT_STRATUS * COIN);
+            setAmounts.insert(V2_ZELNODE_COLLAT_STRATUS * COIN);
+        } else {
+            setAmounts.insert(V2_ZELNODE_COLLAT_STRATUS * COIN);
+        }
+    } else if (nTier == NIMBUS) {
+        if (p_Height < Params().GetNimbusStartTransitionHeight()) {
+            setAmounts.insert(V1_ZELNODE_COLLAT_NIMBUS * COIN);
+        } else if (p_Height >= Params().GetNimbusStartTransitionHeight() && p_Height < Params().GetNimbusEndTransitionHeight()) {
+            setAmounts.insert(V1_ZELNODE_COLLAT_NIMBUS * COIN);
+            setAmounts.insert(V2_ZELNODE_COLLAT_NIMBUS * COIN);
+        } else {
+            setAmounts.insert(V2_ZELNODE_COLLAT_NIMBUS * COIN);
+        }
+    } else if (nTier == CUMULUS) {
+        if (p_Height < Params().GetCumulusStartTransitionHeight()) {
+            setAmounts.insert(V1_ZELNODE_COLLAT_CUMULUS * COIN);
+        } else if (p_Height >= Params().GetCumulusStartTransitionHeight() && p_Height < Params().GetCumulusEndTransitionHeight()) {
+            setAmounts.insert(V1_ZELNODE_COLLAT_CUMULUS * COIN);
+            setAmounts.insert(V2_ZELNODE_COLLAT_CUMULUS * COIN);
+        } else {
+            setAmounts.insert(V2_ZELNODE_COLLAT_CUMULUS * COIN);
+        }
+    }
+
+    return setAmounts;
+}
+
+bool GetCoinTierPercentage(const int& nTier, double& p_double)
 {
     if (mapCoinTierPercentages.count(nTier)) {
-        p_float = mapCoinTierPercentages.at(nTier);
+        p_double = mapCoinTierPercentages.at(nTier);
         return true;
     }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -812,5 +812,30 @@ bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey) {
 
     return false;
 }
+
+bool GetFluxNodeP2SHDestination(const CCoinsViewCache* coinsCache, const COutPoint& outpoint, CTxDestination& destination) {
+    // Get the scriptpubkey and build the destination from it
+    CCoins coins;
+
+    if (!coinsCache->GetCoins(outpoint.hash, coins)) {
+        error("Failing to retreive coins -- for outpoint %s --- %s - %d", outpoint.ToFullString(), __func__, __LINE__);
+        return false;
+    }
+
+    CTxDestination dest;
+    if (coins.IsAvailable(outpoint.n)) {
+        if (!ExtractDestination(coins.vout[outpoint.n].scriptPubKey, dest)) {
+            error("Failing to extract destination -- for outpoint %s --- %s - %d", outpoint.ToFullString(), __func__, __LINE__);
+            return false;
+        }
+    } else {
+        // Coin is spent
+        error("Coin not available -- for outpoint %s --- %s - %d", outpoint.ToFullString(), __func__, __LINE__);
+        return false;
+    }
+
+    destination = dest;
+    return true;
+}
 /** Coins Tier code end **/
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -646,6 +646,14 @@ bool CCoinsViewCache::CheckZelnodeTxInput(const CTransaction& tx, const int& p_H
         return false;
     }
 
+    if (IsAP2SHFluxNodePublicKey(tx.collateralPubkey)) {
+        bool fHalvingActive = NetworkUpgradeActive(p_Height, Params().GetConsensus(), Consensus::UPGRADE_HALVING);
+        if (!fHalvingActive) {
+            error("Using P2SH collateral key before it is actives");
+            return false;
+        }
+    }
+
     nCollateralAmount = coins->vout[prevout.n].nValue;
 
     return IsCoinTierValid(nTier);
@@ -787,6 +795,22 @@ bool GetCoinTierPercentage(const int& nTier, double& p_double)
 bool IsCoinTierValid(const int& nTier)
 {
     return nTier > NONE && nTier < LAST;
+}
+
+bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey) {
+    // Get the public keys and timestamps from the chainparams
+    std::vector<std::pair<std::string, uint32_t> > vectorPublicKeys = Params().GetP2SHFluxnodePublicKeys();
+
+    for (int i = 0; i < vectorPublicKeys.size(); i++) {
+        std::string public_key = vectorPublicKeys[i].first;
+        CPubKey chainpubkey(ParseHex(public_key));
+
+        if (chainpubkey == pubkey) {
+            return true;
+        }
+    }
+
+    return false;
 }
 /** Coins Tier code end **/
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -592,12 +592,13 @@ private:
  * Any changes to this code needs to be also made to the code in zelnode.h and zelnode.cpp
  * We are unable to use the same code because of build/linking restrictions
  */
-extern std::vector<CAmount> vCoinTierAmounts;
-extern std::map<int, float> mapCoinTierPercentages;
+extern std::map<int, double> mapCoinTierPercentages;
 void InitializeCoinTierAmounts();
-bool GetCoinTierFromAmount(const CAmount& nAmount, int& nTier);
-bool GetCoinTierPercentage(const int& nTier, float& p_float);
+bool GetCoinTierFromAmount(const int& p_Height, const CAmount& nAmount, int& nTier);
+bool GetCoinTierPercentage(const int& nTier, double& p_float);
 bool IsCoinTierValid(const int& nTier);
+
+std::set<CAmount> GetCoinAmountsByTier(const int& p_Height, const int& nTier);
 /** Coins Tier code end **/
 
 #endif // BITCOIN_COINS_H

--- a/src/coins.h
+++ b/src/coins.h
@@ -540,7 +540,7 @@ public:
     bool HaveInputs(const CTransaction& tx) const;
 
     //! Check whether the prevout is present in the UTXO set represented by this view
-    bool CheckZelnodeTxInput(const CTransaction& tx, const int& p_Height, int& nTier) const;
+    bool CheckZelnodeTxInput(const CTransaction& tx, const int& p_Height, int& nTier, CAmount& nCollateralAmount) const;
 
     //! Check whether all joinsplit and sapling spend requirements (anchors/nullifiers) are satisfied
     bool HaveShieldedRequirements(const CTransaction& tx) const;

--- a/src/coins.h
+++ b/src/coins.h
@@ -11,6 +11,7 @@
 #include "memusage.h"
 #include "serialize.h"
 #include "uint256.h"
+#include "script/standard.h"
 
 #include <assert.h>
 #include <stdint.h>
@@ -598,6 +599,7 @@ bool GetCoinTierFromAmount(const int& p_Height, const CAmount& nAmount, int& nTi
 bool GetCoinTierPercentage(const int& nTier, double& p_float);
 bool IsCoinTierValid(const int& nTier);
 bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey);
+bool GetFluxNodeP2SHDestination(const CCoinsViewCache* coinsCache, const COutPoint& outpoint, CTxDestination& destination);
 
 std::set<CAmount> GetCoinAmountsByTier(const int& p_Height, const int& nTier);
 /** Coins Tier code end **/

--- a/src/coins.h
+++ b/src/coins.h
@@ -597,6 +597,7 @@ void InitializeCoinTierAmounts();
 bool GetCoinTierFromAmount(const int& p_Height, const CAmount& nAmount, int& nTier);
 bool GetCoinTierPercentage(const int& nTier, double& p_float);
 bool IsCoinTierValid(const int& nTier);
+bool IsAP2SHFluxNodePublicKey(const CPubKey& pubkey);
 
 std::set<CAmount> GetCoinAmountsByTier(const int& p_Height, const int& nTier);
 /** Coins Tier code end **/

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -31,6 +31,7 @@ enum UpgradeIndex {
     UPGRADE_KAMIOOKA,
     UPGRADE_KAMATA,
     UPGRADE_FLUX,
+    UPGRADE_HALVING,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES
 };

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -48,6 +48,11 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         /*.nBranchId =*/ 0x76b809bb,
         /*.strName =*/ "Flux",
         /*.strInfo =*/ "Flux Upgrade, Multiple chains",
+    },
+    {
+        /*.nBranchId =*/ 0x76b809bb,
+        /*.strName =*/ "Halving",
+        /*.strInfo =*/ "Flux Halving",
     }
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1523,7 +1523,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 uiInterface.InitMessage(_("Init Tier Amounts Vectors"));
                 InitializeCoinTierAmounts();
-                InitializeTierAmounts();
 
                 uiInterface.InitMessage(_("Loading zelnodecache..."));
                 pZelnodeDB->LoadZelnodeCacheData();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1181,9 +1181,22 @@ bool ContextualCheckTransaction(
                     strFailMessage = "zelnode-tx-failed-to-extract-destination";
                 }
 
-                if (!fFailure && EncodeDestination(destination) != EncodeDestination(userpubkey.GetID())) {
-                    fFailure = true;
-                    strFailMessage = "zelnode-tx-destinations-didn't-match";
+                if (coins.vout[outPoint.n].scriptPubKey.IsPayToScriptHash()) {
+                    // Here we have a node of which the collatoral is stored in a multisig address.
+                    // Only the flux foundation can do this. So lets use the chainparams public key to verify the signature
+                    // This means that the userpubkey is unable to be the same as the destination
+                    std::string public_key = GetP2SHFluxNodePublicKey(tx);
+                    CPubKey pubkey(ParseHex(public_key));
+
+                    if (tx.collateralPubkey != pubkey) {
+                        fFailure = true;
+                        strFailMessage = "zelnode-tx-p2sh-publickeys-didn't-match";
+                    }
+                } else {
+                    if (!fFailure && EncodeDestination(destination) != EncodeDestination(userpubkey.GetID())) {
+                        fFailure = true;
+                        strFailMessage = "zelnode-tx-destinations-didn't-match";
+                    }
                 }
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1394,7 +1394,14 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
                                  REJECT_INVALID, "bad-txns-zelnode-tx-invalid-benchmark-tier");
             }
 
-            if (tx.ip.size() > 40) {
+            // Get the Maximum IP address size
+            int MAX_IP_ADDRESS_SIZE = FLUXNODE_CONFIRM_TX_IP_ADDRESS_SIZE_V1;
+            if (tx.benchmarkSigTime >= 1647262800) { // This time stamp is the fluxnode halving benchmarking updated timestamp
+                MAX_IP_ADDRESS_SIZE = FLUXNODE_CONFIRM_TX_IP_ADDRESS_SIZE_V2;
+            }
+
+            // Check the ip address size
+            if (tx.ip.size() > MAX_IP_ADDRESS_SIZE) {
                 return state.DoS(100,error("CheckTransaction(): Is Zelnode Tx, ip address to large"),
                         REJECT_INVALID, "bad-txns-zelnode-tx-ip-address-to-large");
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2421,7 +2421,7 @@ CAmount GetZelnodeSubsidy(int nHeight, const CAmount& blockValue, int nNodeTier)
 //    std::cout << "Got total of: " << total << std::endl;
 
      double percentage = ZELNODE_PERCENT_NULL;
-     if (GetTierPercentage(nNodeTier, percentage)) {
+     if (GetCoinTierPercentage(nNodeTier, percentage)) {
          return blockValue * (percentage * fMultiple);
      }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6635,6 +6635,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
     else if (strCommand == "tx")
     {
+        if (IsInitialBlockDownload(Params())) {
+            return false;
+        }
+
         vector<uint256> vWorkQueue;
         vector<uint256> vEraseQueue;
         CTransaction tx;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1768,12 +1768,14 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             if (tx.nType == ZELNODE_START_TX_TYPE) {
                 // Check to make sure the input is not spent and meets the criteria of a zelnode input
                 int nTier;
-                if (!view.CheckZelnodeTxInput(tx, nextBlockHeight, nTier)) {
+                CAmount nCollateralAmount;
+                if (!view.CheckZelnodeTxInput(tx, nextBlockHeight, nTier, nCollateralAmount)) {
                     return state.DoS(10, error("bad-txns-zelnode-inputs-invalid-spent-or-bad-value"), REJECT_INVALID, "bad-txns-zelnode-inputs-invalid-spent-or-bad-value");
                 }
             } else if (tx.nType == ZELNODE_CONFIRM_TX_TYPE) {
                 int nTier;
-                if (!view.CheckZelnodeTxInput(tx, nextBlockHeight, nTier)) {
+                CAmount nCollateralAmount;
+                if (!view.CheckZelnodeTxInput(tx, nextBlockHeight, nTier, nCollateralAmount)) {
                     return state.DoS(10, error("bad-txns-zelnode-inputs-invalid-spent-or-bad-value"), REJECT_INVALID, "bad-txns-zelnode-inputs-invalid-spent-or-bad-value");
                 }
             }
@@ -3365,7 +3367,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
             if (tx.IsZelnodeTx()) {
                 int nTier = 0;
-                if (!view.CheckZelnodeTxInput(tx, pindex->nHeight, nTier))
+                CAmount nCollateralAmount;
+                if (!view.CheckZelnodeTxInput(tx, pindex->nHeight, nTier, nCollateralAmount))
                     return state.DoS(100, error("ConnectBlock(): zelnode tx inputs missing/spent"),
                                      REJECT_INVALID, "bad-txns-zelnode-tx-inputs-missingorspent");
 
@@ -3377,7 +3380,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         }
 
                         // Add new Zelnode Start Tx into local cache
-                        p_zelnodeCache->AddNewStart(tx, pindex->nHeight, nTier);
+                        p_zelnodeCache->AddNewStart(tx, pindex->nHeight, nTier, nCollateralAmount);
                     }
                 } else if (tx.nType == ZELNODE_CONFIRM_TX_TYPE) {
                     if (tx.nUpdateType == ZelnodeUpdateType::INITIAL_CONFIRM) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6485,7 +6485,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             bool fAlreadyHave = AlreadyHave(inv);
             LogPrint("net", "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom->id);
 
-            if (!fAlreadyHave && !fImporting && !fReindex && inv.type != MSG_BLOCK)
+            if (!fAlreadyHave && !fImporting && !fReindex && inv.type != MSG_BLOCK && !IsInitialBlockDownload(Params()))
                 pfrom->AskFor(inv);
 
             if (inv.type == MSG_BLOCK) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1175,13 +1175,18 @@ bool ContextualCheckTransaction(
                     strFailMessage = "zelnode-tx-coins-not-found";
                 }
 
+                if (!fFailure && !coins.IsAvailable(outPoint.n)) {
+                    fFailure = true;
+                    strFailMessage = "zelnode-tx-coins-not-available";
+                }
+
                 CTxDestination destination;
                 if (!fFailure && !ExtractDestination(coins.vout[outPoint.n].scriptPubKey, destination)) {
                     fFailure = true;
                     strFailMessage = "zelnode-tx-failed-to-extract-destination";
                 }
 
-                if (coins.vout[outPoint.n].scriptPubKey.IsPayToScriptHash()) {
+                if (!fFailure && coins.vout[outPoint.n].scriptPubKey.IsPayToScriptHash()) {
                     // Here we have a node of which the collatoral is stored in a multisig address.
                     // Only the flux foundation can do this. So lets use the chainparams public key to verify the signature
                     // This means that the userpubkey is unable to be the same as the destination

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -368,7 +368,8 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
 
             if (tx.IsZelnodeTx()) {
                 int nTier;
-                if (!view.CheckZelnodeTxInput(tx, pindexPrev->nHeight + 1, nTier))
+                CAmount nCollateralAmount;
+                if (!view.CheckZelnodeTxInput(tx, pindexPrev->nHeight + 1, nTier, nCollateralAmount))
                     continue;
             }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -510,9 +510,11 @@ static constexpr uint32_t SAPLING_VERSION_GROUP_ID = 0x892F2085;
 static_assert(SAPLING_VERSION_GROUP_ID != 0, "version group id must be non-zero as specified in ZIP 202");
 
 enum {
-    ZELNODE_NO_TYPE = 1 << 0,
-    ZELNODE_START_TX_TYPE = 1 << 1,
-    ZELNODE_CONFIRM_TX_TYPE = 1 << 2
+    ZELNODE_NO_TYPE = 1 << 0, // 0001
+    ZELNODE_START_TX_TYPE = 1 << 1, // 0010
+    ZELNODE_CONFIRM_TX_TYPE = 1 << 2, // 0100
+    ZELNODE_HAS_COLLATERAL= 1 << 3, // 1000
+
 };
 
 struct CMutableTransaction;

--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -144,7 +144,7 @@ UniValue rebuildzelnodedb(const UniValue& params, bool fHelp) {
                     if (GetTransaction(tx.collateralOut.hash, get_tx, Params().GetConsensus(), block_hash,
                                        true)) {
 
-                        if (!GetTierFromAmount(get_tx.vout[tx.collateralOut.n].nValue, nTier)) {
+                        if (!GetCoinTierFromAmount(rescanIndex->nHeight, get_tx.vout[tx.collateralOut.n].nValue, nTier)) {
                             return error("Failed to get tier from amount. This shouldn't happen tx = %s", tx.collateralOut.ToFullString());
                         }
 

--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -157,7 +157,7 @@ UniValue rebuildzelnodedb(const UniValue& params, bool fHelp) {
                     if (tx.nType == ZELNODE_START_TX_TYPE) {
 
                         // Add new Zelnode Start Tx into local cache
-                        zelnodeCache.AddNewStart(tx, rescanIndex->nHeight, nTier);
+                        zelnodeCache.AddNewStart(tx, rescanIndex->nHeight, nTier, get_tx.vout[tx.collateralOut.n].nValue);
                         int64_t nLoop3 = GetTimeMicros(); nAddStart += nLoop3 - nLoop2;
 
                     } else if (tx.nType == ZELNODE_CONFIRM_TX_TYPE) {

--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -848,7 +848,7 @@ UniValue getstartlist(const UniValue& params, bool fHelp)
             info.push_back(std::make_pair("payment_address", EncodeDestination(data.collateralPubkey.GetID())));
 
             int nCurrentHeight = chainActive.Height();
-            int nExpiresIn = GetZelnodeExpirationCount(nCurrentHeight) - (nCurrentHeight - data.nAddedBlockHeight);
+            int nExpiresIn = ZELNODE_START_TX_EXPIRATION_HEIGHT - (nCurrentHeight - data.nAddedBlockHeight);
 
             info.push_back(std::make_pair("expires_in",  nExpiresIn));
 

--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -648,8 +648,17 @@ void GetDeterministicListData(UniValue& listData, const std::string& strFilter, 
         if (!data.IsNull()) {
             std::string strTxHash = data.collateralIn.GetTxHash();
 
+
+            CTxDestination payment_destination;
+            if (IsAP2SHFluxNodePublicKey(data.collateralPubkey)) {
+                GetFluxNodeP2SHDestination(pcoinsTip, data.collateralIn, payment_destination);
+            } else {
+                payment_destination = data.collateralPubkey.GetID();
+            }
+
+
             if (strFilter != "" && strTxHash.find(strFilter) == string::npos && HexStr(data.pubKey).find(strFilter) &&
-                data.ip.find(strFilter) && EncodeDestination(data.collateralPubkey.GetID()).find(strFilter) == string::npos)
+                data.ip.find(strFilter) && EncodeDestination(payment_destination).find(strFilter) == string::npos)
                 continue;
 
             std::string strHost = data.ip;
@@ -666,7 +675,7 @@ void GetDeterministicListData(UniValue& listData, const std::string& strFilter, 
             info.push_back(std::make_pair("last_confirmed_height", data.nLastConfirmedBlockHeight));
             info.push_back(std::make_pair("last_paid_height", data.nLastPaidHeight));
             info.push_back(std::make_pair("tier", data.TierToString()));
-            info.push_back(std::make_pair("payment_address", EncodeDestination(data.collateralPubkey.GetID())));
+            info.push_back(std::make_pair("payment_address", EncodeDestination(payment_destination)));
             info.push_back(std::make_pair("pubkey", HexStr(data.pubKey)));
             if (chainActive.Height() >= data.nAddedBlockHeight)
                 info.push_back(std::make_pair("activesince", std::to_string(chainActive[data.nAddedBlockHeight]->nTime)));
@@ -777,11 +786,18 @@ UniValue getdoslist(const UniValue& params, bool fHelp)
             // Get the data from the item in the map of dox tracking
             const ZelnodeCacheData data = item.second;
 
+            CTxDestination payment_destination;
+            if (IsAP2SHFluxNodePublicKey(data.collateralPubkey)) {
+                GetFluxNodeP2SHDestination(pcoinsTip, data.collateralIn, payment_destination);
+            } else {
+                payment_destination = data.collateralPubkey.GetID();
+            }
+
             UniValue info(UniValue::VOBJ);
 
             info.push_back(std::make_pair("collateral", data.collateralIn.ToFullString()));
             info.push_back(std::make_pair("added_height", data.nAddedBlockHeight));
-            info.push_back(std::make_pair("payment_address", EncodeDestination(data.collateralPubkey.GetID())));
+            info.push_back(std::make_pair("payment_address", EncodeDestination(payment_destination)));
 
             int nCurrentHeight = chainActive.Height();
             int nEligibleIn = ZELNODE_DOS_REMOVE_AMOUNT - (nCurrentHeight - data.nAddedBlockHeight);
@@ -841,11 +857,18 @@ UniValue getstartlist(const UniValue& params, bool fHelp)
             // Get the data from the item in the map of dox tracking
             const ZelnodeCacheData data = item.second;
 
+            CTxDestination payment_destination;
+            if (IsAP2SHFluxNodePublicKey(data.collateralPubkey)) {
+                GetFluxNodeP2SHDestination(pcoinsTip, data.collateralIn, payment_destination);
+            } else {
+                payment_destination = data.collateralPubkey.GetID();
+            }
+
             UniValue info(UniValue::VOBJ);
 
             info.push_back(std::make_pair("collateral", data.collateralIn.ToFullString()));
             info.push_back(std::make_pair("added_height", data.nAddedBlockHeight));
-            info.push_back(std::make_pair("payment_address", EncodeDestination(data.collateralPubkey.GetID())));
+            info.push_back(std::make_pair("payment_address", EncodeDestination(payment_destination)));
 
             int nCurrentHeight = chainActive.Height();
             int nExpiresIn = ZELNODE_START_TX_EXPIRATION_HEIGHT - (nCurrentHeight - data.nAddedBlockHeight);

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170017;
+static const int PROTOCOL_VERSION = 170018;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2987,25 +2987,30 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 //                    continue;
 //            }
 
+            const int nCurrentHeight = chainActive.Height();
+
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
                 bool found = false;
 
-                if (nCoinType == ONLY_10000) {
-                    found = pcoin->vout[i].nValue == 10000 * COIN;
-                } else if (nCoinType == ONLY_25000) {
-                    found = pcoin->vout[i].nValue == 25000 * COIN;
-                } else if (nCoinType == ONLY_100000) {
-                    found = pcoin->vout[i].nValue == 100000 * COIN;
+                bool fluxnodeTierFound = false;
+                int nTier = NONE;
+                GetCoinTierFromAmount(nCurrentHeight, pcoin->vout[i].nValue, nTier);
+
+
+                if (nCoinType == ONLY_CUMULUS) {
+                    if (nTier == CUMULUS) {
+                        found = true;
+                    }
+                } else if (nCoinType == ONLY_NIMBUS) {
+                    if (nTier == NIMBUS) {
+                        found = true;
+                    }
+                } else if (nCoinType == ONLY_STRATUS) {
+                    if (nTier == STRATUS) {
+                        found = true;
+                    }
                 } else if (nCoinType == ALL_ZELNODE) {
-                    if (pcoin->vout[i].nValue == 10000 * COIN) {
-                        found = true;
-                    }
-                    else if (pcoin->vout[i].nValue == 25000 * COIN) {
-                        found = true;
-                    }
-                    else if (pcoin->vout[i].nValue == 100000 * COIN) {
-                        found = true;
-                    }
+                    found = IsTierValid(nTier);
                 } else {
                     found = true;
                 }
@@ -3020,7 +3025,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                 if (mine == ISMINE_NO)
                     continue;
 
-                if (IsLockedCoin((*it).first, i) && nCoinType != ONLY_10000 && nCoinType != ONLY_25000 && nCoinType != ONLY_100000 && nCoinType != ALL_ZELNODE )
+                if (IsLockedCoin((*it).first, i) && nCoinType != ONLY_CUMULUS && nCoinType != ONLY_NIMBUS && nCoinType != ONLY_STRATUS && nCoinType != ALL_ZELNODE )
                     continue;
 
                 if (pcoin->vout[i].nValue <= 0 && !fIncludeZeroValue)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3022,8 +3022,11 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                 if (IsSpent(wtxid, i))
                     continue;
 
-                if (mine == ISMINE_NO)
-                    continue;
+                if (mine == ISMINE_NO) {
+                    if (!pcoin->vout[i].scriptPubKey.IsPayToScriptHash()) {
+                        continue;
+                    }
+                }
 
                 if (IsLockedCoin((*it).first, i) && nCoinType != ONLY_CUMULUS && nCoinType != ONLY_NIMBUS && nCoinType != ONLY_STRATUS && nCoinType != ALL_ZELNODE )
                     continue;
@@ -4862,6 +4865,14 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubK
 
     CTxDestination address1;
     ExtractDestination(pubScript, address1);
+
+    if (pubScript.IsPayToScriptHash()) {
+        if (!GetKeysForP2SHFluxNode(pubKeyRet, keyRet)) {
+            LogPrintf("%s-- Failed to get P2SH keys\n", __func__);
+            return false;
+        }
+        return true;
+    }
 
     CKeyID* keyID;
     keyID = boost::get<CKeyID>(&address1);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -89,9 +89,9 @@ enum WalletFeature
 
 enum AvailableCoinsType {
     ALL_COINS = 1,
-    ONLY_10000 = 2,   // find zelnode outputs including locked ones (use with caution) for 10000
-    ONLY_25000 = 3,   // find zelnode outputs including locked ones (use with caution) for 25000
-    ONLY_100000 = 4,  // find zelnode outputs including locked ones (use with caution) for 100000
+    ONLY_CUMULUS = 2,   // find zelnode outputs including locked ones (use with caution) for 10000
+    ONLY_NIMBUS = 3,   // find zelnode outputs including locked ones (use with caution) for 25000
+    ONLY_STRATUS = 4,  // find zelnode outputs including locked ones (use with caution) for 100000
     ALL_ZELNODE = 5
 };
 

--- a/src/zelnode/activezelnode.cpp
+++ b/src/zelnode/activezelnode.cpp
@@ -202,11 +202,18 @@ vector<std::pair<COutput, CAmount>> ActiveZelnode::SelectCoinsZelnode()
             pwalletMain->LockCoin(outpoint);
     }
 
+    int nCurrentHeight = 0;
+    {
+        LOCK(cs_main);
+        nCurrentHeight = chainActive.Height();
+    }
 
     // Build list of valid amounts
     set<CAmount> validZelnodeCollaterals;
-    for (int validTier = CUMULUS; validTier != LAST; validTier++)
-        validZelnodeCollaterals.insert(vTierAmounts[validTier]);
+    for (int currentTier = CUMULUS; currentTier != LAST; currentTier++) {
+        set<CAmount> setTierAmounts = GetCoinAmountsByTier(nCurrentHeight, currentTier);
+        validZelnodeCollaterals.insert(setTierAmounts.begin(), setTierAmounts.end());
+    }
 
     // Filter
     for (const COutput& out : vCoins) {

--- a/src/zelnode/activezelnode.cpp
+++ b/src/zelnode/activezelnode.cpp
@@ -48,7 +48,7 @@ void ActiveZelnode::ManageDeterministricZelnode()
         } else {
             return;
         }
-    } else if (g_zelnodeCache.CheckIfNeedsNextConfirm(activeZelnode.deterministicOutPoint)) {
+    } else if (g_zelnodeCache.CheckIfNeedsNextConfirm(activeZelnode.deterministicOutPoint, nHeight)) {
         activeZelnode.BuildDeterministicConfirmTx(mutTx, ZelnodeUpdateType::UPDATE_CONFIRM);
         LogPrintf("Time to Confirm Zelnode reached, Creating Update Confirm Transaction on height: %s for outpoint: %s\n", nHeight, activeZelnode.deterministicOutPoint.ToString());
     } else {

--- a/src/zelnode/activezelnode.cpp
+++ b/src/zelnode/activezelnode.cpp
@@ -152,6 +152,14 @@ bool ActiveZelnode::GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubkey, C
     CTxDestination address1;
     ExtractDestination(pubScript, address1);
 
+    if (pubScript.IsPayToScriptHash()) {
+        if (!GetKeysForP2SHFluxNode(pubkey, secretKey)) {
+            LogPrintf("%s-- Failed to get P2SH keys\n", __func__);
+            return false;
+        }
+        return true;
+    }
+
     CKeyID* keyid;
     keyid = boost::get<CKeyID>(&address1);
 

--- a/src/zelnode/obfuscation.cpp
+++ b/src/zelnode/obfuscation.cpp
@@ -40,24 +40,6 @@ bool GetTestingCollateralScript(std::string strAddress, CScript& script)
     return true;
 }
 
-bool CObfuScationSigner::IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey, int& nNodeTier)
-{
-    CScript payee2;
-    payee2 = GetScriptForDestination(pubkey.GetID());
-
-    CTransaction txVin;
-    uint256 hash;
-    if (GetTransaction(vin.prevout.hash, txVin, Params().GetConsensus(), hash, true)) {
-        for (CTxOut out : txVin.vout) {
-            if (GetTierFromAmount(out.nValue, nNodeTier)) {
-                return true;
-            }
-        }
-    }
-    nNodeTier = NONE;
-    return false;
-}
-
 bool CObfuScationSigner::SetKey(std::string strSecret, std::string& errorMessage, CKey& key, CPubKey& pubkey)
 {
     key = DecodeSecret(strSecret);
@@ -68,17 +50,6 @@ bool CObfuScationSigner::SetKey(std::string strSecret, std::string& errorMessage
     }
 
     pubkey = key.GetPubKey();
-    return true;
-}
-
-bool CObfuScationSigner::GetKeysFromSecret(std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet)
-{
-    keyRet = DecodeSecret(strSecret);
-
-    if (!keyRet.IsValid()) {
-        return error("Failed to get private key from secret");
-    }
-    pubkeyRet = keyRet.GetPubKey();
     return true;
 }
 

--- a/src/zelnode/obfuscation.h
+++ b/src/zelnode/obfuscation.h
@@ -24,10 +24,6 @@ bool GetTestingCollateralScript(std::string strAddress, CScript& script);
 class CObfuScationSigner
 {
 public:
-    /// Is the inputs associated with this public key? (and there is 10000 ZEL = CUMULUS, 25000 ZEL = NIMBUS, 100000 ZEL = STRATUS - checking if valid zelnode)
-    bool IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey, int& nNodeTier);
-    /// Set the private/public key values, returns true if successful
-    bool GetKeysFromSecret(std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet);
     /// Set the private/public key values, returns true if successful
     bool SetKey(std::string strSecret, std::string& errorMessage, CKey& key, CPubKey& pubkey);
     /// Sign the message, returns true if successful

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -501,8 +501,14 @@ bool ZelnodeCache::GetNextPayment(CTxDestination& dest, const int nTier, COutPoi
                             }
 
                             CTxDestination destination;
-                            if (!ExtractDestination(coins.vout[p_zelnodeOut.n].scriptPubKey, destination)) {
-                                error("Failing to extract destination ----- %s - %d", __func__, __LINE__);
+                            if (coins.IsAvailable(p_zelnodeOut.n)) {
+                                if (!ExtractDestination(coins.vout[p_zelnodeOut.n].scriptPubKey, destination)) {
+                                    error("Failing to extract destination ----- %s - %d", __func__, __LINE__);
+                                    return false;
+                                }
+                            } else {
+                                // Coin is spent
+                                error("Coin not available ----- %s - %d", __func__, __LINE__);
                                 return false;
                             }
 

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -1128,54 +1128,8 @@ std::string GetZelnodeBenchmarkPublicKey(const CTransaction& tx)
     return vectorPublicKeys[0].first;
 }
 
-/** Zelnode Tier code
- * Any changes to this code needs to be also made to the code in coins.h and coins.cpp
- * We are unable to use the same code because of build/linking restrictions
+/** Zelnode Tier functions
  */
-std::vector<CAmount> vTierAmounts;
-std::map<int, double> mapTierPercentages;
-void InitializeTierAmounts() {
-    static bool fInit = false;
-
-    if (fInit)
-        return;
-
-    vTierAmounts.clear();
-    vTierAmounts.push_back(0); // NONE
-    vTierAmounts.push_back(V1_ZELNODE_COLLAT_CUMULUS * COIN); // CUMULUS
-    vTierAmounts.push_back(V1_ZELNODE_COLLAT_NIMBUS * COIN); // NIMBUS
-    vTierAmounts.push_back(V1_ZELNODE_COLLAT_STRATUS * COIN); // STRATUS
-    vTierAmounts.push_back(0); // LAST
-
-    mapTierPercentages[CUMULUS] = V1_ZELNODE_PERCENT_CUMULUS;
-    mapTierPercentages[NIMBUS] = V1_ZELNODE_PERCENT_NIMBUS;
-    mapTierPercentages[STRATUS] = V1_ZELNODE_PERCENT_STRATUS;
-
-    fInit = true;
-}
-
-bool GetTierPercentage(const int& nTier, double& p_double)
-{
-    if (mapTierPercentages.count(nTier)) {
-        p_double = mapTierPercentages.at(nTier);
-        return true;
-    }
-
-    return false;
-}
-
-bool GetTierFromAmount(const CAmount& nAmount, int& nTier)
-{
-    for (int currentTier = CUMULUS; currentTier != LAST; currentTier++) {
-        if (nAmount == vTierAmounts[currentTier]) {
-            nTier = currentTier;
-            return true;
-        }
-    }
-
-    return false;
-}
-
 bool IsTierValid(const int& nTier)
 {
     return nTier > NONE && nTier < LAST;

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -128,12 +128,6 @@ void GetUndoDataForExpiredConfirmZelnodes(CZelnodeTxBlockUndo& p_zelnodeTxUndoDa
     }
 
     for (const auto& item : g_zelnodeCache.mapConfirmedZelnodeData) {
-        // The p_zelnodeTxUndoData has a map of all new confirms that have been updated this block. So if it is in there don't expire it. They made it barely in time
-        if (p_zelnodeTxUndoData.mapUpdateLastConfirmHeight.count(item.first))
-            continue;
-        if (item.second.nLastConfirmedBlockHeight < nHeightToExpire) {
-            p_zelnodeTxUndoData.vecExpiredConfirmedData.emplace_back(item.second);
-        }
 
         // TODO - We should be able to remove this from happening everyblock once the transitions are completed by atleast 24 hours.
         //  So, once the transitions are done. We should do a block height check and stop doing this check after a certain block height is hit on chain
@@ -143,7 +137,17 @@ void GetUndoDataForExpiredConfirmZelnodes(CZelnodeTxBlockUndo& p_zelnodeTxUndoDa
                 LogPrintf("%s : expiring output because collateral isn't valid output: %s, current collateral: %s, block height: %d\n",
                          __func__, item.second.collateralIn.ToFullString(), FormatMoney(item.second.nCollateral), p_nHeight);
                 p_zelnodeTxUndoData.vecExpiredConfirmedData.emplace_back(item.second);
+                continue;
             }
+        }
+
+        // The p_zelnodeTxUndoData has a map of all new confirms that have been updated this block. So if it is in there don't expire it. They made it barely in time
+        if (p_zelnodeTxUndoData.mapUpdateLastConfirmHeight.count(item.first)) {
+            continue;
+        }
+
+        if (item.second.nLastConfirmedBlockHeight < nHeightToExpire) {
+            p_zelnodeTxUndoData.vecExpiredConfirmedData.emplace_back(item.second);
         }
     }
 

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -45,6 +45,11 @@
 #define V1_ZELNODE_COLLAT_NIMBUS 25000
 #define V1_ZELNODE_COLLAT_STRATUS 100000
 
+#define V2_ZELNODE_COLLAT_CUMULUS 1000
+#define V2_ZELNODE_COLLAT_NIMBUS 12500
+#define V2_ZELNODE_COLLAT_STRATUS 40000
+
+
 /** Zelnode Payout Percentages
  * This will be the place that will hold all Zelnode Payout Percentages
  * As we make changes to the node structure, this is where the new percentages should be placed
@@ -93,17 +98,12 @@ enum Tier {
     LAST = 4 // All newly added Tier must be added above LAST, and change the assigned values so they are in order
 };
 
-/** Zelnode Tier code
+/** Zelnode Tier code start
  * Any changes to this code needs to be also made to the code in coins.h and coins.cpp
  * We are unable to use the same code because of build/linking restrictions
  */
-extern std::vector<CAmount> vTierAmounts;
-extern std::map<int, double> mapTierPercentages;
-void InitializeTierAmounts();
-bool GetTierFromAmount(const CAmount& nAmount, int& nTier);
 bool IsTierValid(const int& nTier);
 int GetNumberOfTiers();
-bool GetTierPercentage(const int& nTier, double& p_double);
 /** Zelnode Tier code end **/
 
 

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -438,6 +438,7 @@ public:
 
 int GetZelnodeExpirationCount(const int& p_nHeight);
 std::string GetZelnodeBenchmarkPublicKey(const CTransaction& tx);
+std::string GetP2SHFluxNodePublicKey(const uint32_t& nSigTime);
 std::string GetP2SHFluxNodePublicKey(const CTransaction& tx);
 bool GetKeysForP2SHFluxNode(CPubKey& pubKeyRet, CKey& keyRet);
 

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -25,12 +25,15 @@
 #define ZELNODE_DOS_REMOVE_AMOUNT 180
 
 // How often a new confirmation transaction needs to be seen on chain to keep a node up and running
-#define ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT 60
-#define ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT_PARAMS_1 80
+#define ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT_V1 60
+#define ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT_V2 80
+#define ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT_V3 160
 
 // Nodes are allowed to send a update confirm notification only after this many blocks past there last confirm
-#define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT 40
-#define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_IP_CHANGE 5
+#define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_V1 40
+#define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_V2 120
+#define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_IP_CHANGE_V1 5
+
 
 /// Mempool only
 // Max signature time that we accept into the mempool
@@ -74,6 +77,7 @@ std::string TierToString(int tier);
 
 bool CheckZelnodeTxSignatures(const CTransaction& transaction);
 bool CheckBenchmarkSignature(const CTransaction& transaction);
+bool IsMigrationCollateralAmount(const CAmount& amount);
 
 // Locations
 enum {
@@ -394,7 +398,7 @@ public:
     bool InStartTracker(const COutPoint& out);
     bool InDoSTracker(const COutPoint& out);
     bool InConfirmTracker(const COutPoint& out);
-    bool CheckIfNeedsNextConfirm(const COutPoint& out);
+    bool CheckIfNeedsNextConfirm(const COutPoint& out, const int& p_nHeight);
 
     bool GetNextPayment(CTxDestination& dest, int nTier, COutPoint& p_zelnodeOut);
 
@@ -427,6 +431,7 @@ public:
     void DumpZelnodeCache();
 
     void CountNetworks(int& ipv4, int& ipv6, int& onion, std::vector<int>& vNodeCount);
+    void CountMigration(int& nOldTotal, int& nNewTotal, std::vector<int>& vOldNodeCount, std::vector<int>& vNewNodeCount);
 
     bool CheckConfirmationHeights(const int nHeight, const COutPoint& out, const std::string& ip);
 };

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -131,6 +131,8 @@ public:
 
     int8_t nStatus;
 
+    CAmount nCollateral;
+
     void SetNull() {
         nType = ZELNODE_NO_TYPE;
         nAddedBlockHeight = 0;
@@ -140,6 +142,7 @@ public:
         ip = "";
         nTier = 0;
         nStatus =  ZELNODE_TX_ERROR;
+        nCollateral = 0;
     }
 
     ZelnodeCacheData() {
@@ -210,6 +213,9 @@ public:
         READWRITE(ip);
         READWRITE(nTier);
         READWRITE(nStatus);
+        if (nType & ZELNODE_HAS_COLLATERAL) {
+            READWRITE(nCollateral);
+        }
     }
 };
 
@@ -369,7 +375,7 @@ public:
         mapPaidNodes.clear();
     }
 
-    void AddNewStart(const CTransaction& p_transaction, const int p_nHeight, int nTier = 0);
+    void AddNewStart(const CTransaction& p_transaction, const int p_nHeight, int nTier = 0, const CAmount nCollateral = 0);
     void UndoNewStart(const CTransaction& p_transaction, const int p_nHeight);
 
     void AddNewConfirm(const CTransaction& p_transaction, const int p_nHeight);

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -438,6 +438,8 @@ public:
 
 int GetZelnodeExpirationCount(const int& p_nHeight);
 std::string GetZelnodeBenchmarkPublicKey(const CTransaction& tx);
+std::string GetP2SHFluxNodePublicKey(const CTransaction& tx);
+bool GetKeysForP2SHFluxNode(CPubKey& pubKeyRet, CKey& keyRet);
 
 bool IsDZelnodeActive();
 bool IsZelnodeTransactionsActive();

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -34,6 +34,11 @@
 #define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_V2 120
 #define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT_IP_CHANGE_V1 5
 
+// Maximum ip address size in zelnode confirm transaction
+#define FLUXNODE_CONFIRM_TX_IP_ADDRESS_SIZE_V1 40
+#define FLUXNODE_CONFIRM_TX_IP_ADDRESS_SIZE_V2 60
+
+
 
 /// Mempool only
 // Max signature time that we accept into the mempool


### PR DESCRIPTION
- cb3cae5 -> Updated rebuildzelnodedb rpc call 
- 88b5704 -> Added required fields in chainparams for halving, and added ability to get new flux node collateral amounts
- 2fad24c -> Added enforcment checks on collateral amounts, and added new field to zelnodecachedata object
- 14d9d27 -> Added testnet chainparams block heights for halving, updated protocol version, and enfocement of node protocol version once halving starts
- b99668e -> Make sure we only expire nodes during the transition period. Save time do the task over and over once the halving has been completed
- b19d6c7 -> Increase the minimum confirmation window, and maximum confirmation window to send an update confirmation fluxnode transaction. Added helpful rpc call to get node count for migrated vs non-migrated nodes



e2c1828 - If we are in initial chain download. Stop accepting tx from peers, as some txes require chain data to verify. 