### PR TITLE
[Info] Fix network not populating on flux node list when using multiport

### DIFF
--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -661,8 +661,10 @@ void GetDeterministicListData(UniValue& listData, const std::string& strFilter, 
                 data.ip.find(strFilter) && EncodeDestination(payment_destination).find(strFilter) == string::npos)
                 continue;
 
-            std::string strHost = data.ip;
-            CNetAddr node = CNetAddr(strHost, false);
+            std::string host;
+            int port;
+            SplitHostPort(data.ip, port, host);
+            CNetAddr node = CNetAddr(host, false);
             std::string strNetwork = GetNetworkName(node.GetNetwork());
 
             info.pushKV("collateral", data.collateralIn.ToFullString());


### PR DESCRIPTION
- Added separation of host and port from ip string before assigning the network