### PR TITLE
Logs spam

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3926,7 +3926,7 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
         if (!HaveKey(keypool.vchPubKey.GetID()))
             throw runtime_error("ReserveKeyFromKeyPool(): unknown key in key pool");
         assert(keypool.vchPubKey.IsValid());
-        LogPrintf("keypool reserve %d\n", nIndex);
+        LogPrint("wallet", "keypool reserve %d\n", nIndex);
     }
 }
 
@@ -3948,7 +3948,7 @@ void CWallet::ReturnKey(int64_t nIndex)
         LOCK(cs_wallet);
         setKeyPool.insert(nIndex);
     }
-    LogPrintf("keypool return %d\n", nIndex);
+    LogPrint("wallet", "keypool return %d\n", nIndex);
 }
 
 bool CWallet::GetKeyFromPool(CPubKey& result)


### PR DESCRIPTION
My fluxnodes see this happening constantly. Over and over nonstop. Move these logs to wallet keyword logging
` keypool reserve 2
2022-03-29 02:13:19 keypool return 2
2022-03-29 02:13:24 keypool reserve 2
2022-03-29 02:13:24 keypool return 2
2022-03-29 02:13:29 keypool reserve 2
2022-03-29 02:13:29 keypool return 2
2022-03-29 02:13:34 keypool reserve 2
2022-03-29 02:13:34 keypool return 2
`
