### PR TITLE
Add ability to create snapshots

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -179,6 +179,7 @@ BITCOIN_CORE_H = \
   serialize.h \
   spentindex.h \
   streams.h \
+  snapshot/snapshotdb.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
   support/cleanse.h \
@@ -271,6 +272,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/server.cpp \
   rpc/zelnode.cpp \
   script/sigcache.cpp \
+  snapshot/snapshotdb.cpp \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -59,6 +59,7 @@ bool CCoinsView::BatchWrite(CCoinsMap &mapCoins,
                             CNullifiersMap &mapSproutNullifiers,
                             CNullifiersMap &mapSaplingNullifiers) { return false; }
 bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
+bool CCoinsView::GetAllBalances(std::map<std::string, CAmount> &mapBalances) const { return false; }
 
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) { }
@@ -80,6 +81,7 @@ bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins,
                                   CNullifiersMap &mapSproutNullifiers,
                                   CNullifiersMap &mapSaplingNullifiers) { return base->BatchWrite(mapCoins, hashBlock, hashSproutAnchor, hashSaplingAnchor, mapSproutAnchors, mapSaplingAnchors, mapSproutNullifiers, mapSaplingNullifiers); }
 bool CCoinsViewBacked::GetStats(CCoinsStats &stats) const { return base->GetStats(stats); }
+bool CCoinsViewBacked::GetAllBalances(std::map<std::string, CAmount> &mapBalances) const { return base->GetAllBalances(mapBalances); }
 
 CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -377,6 +377,8 @@ public:
     //! Calculate statistics about the unspent transaction output set
     virtual bool GetStats(CCoinsStats &stats) const;
 
+    virtual bool GetAllBalances(std::map<std::string, CAmount>& mapBalances) const;
+
     //! As we use CCoinsViews polymorphically, have a virtual destructor
     virtual ~CCoinsView() {}
 };
@@ -407,6 +409,7 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers);
     bool GetStats(CCoinsStats &stats) const;
+    bool GetAllBalances(std::map<std::string, CAmount> &mapBalances) const;
 };
 
 

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -70,6 +70,10 @@ public:
     bool GetStats(CCoinsStats &stats) const {
         return false;
     }
+
+    bool GetAllBalances(std::map<std::string, CAmount> &mapBalances) const {
+        return false;
+    }
 };
 
 TEST(Mempool, PriorityStatsDoNotCrash) {

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -71,6 +71,10 @@ public:
     bool GetStats(CCoinsStats &stats) const {
         return false;
     }
+
+    bool GetAllBalances(std::map<std::string, CAmount> &mapBalances) const {
+        return false;
+    }
 };
 
 TEST(TransactionBuilder, TransparentToSapling)

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -70,6 +70,10 @@ public:
     bool GetStats(CCoinsStats &stats) const {
         return false;
     }
+
+    bool GetAllBalances(std::map<std::string, CAmount> &mapBalances) const {
+        return false;
+    }
 };
 
 TEST(Validation, ContextualCheckInputsPassesWithCoinbase) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -42,6 +42,7 @@
 #include "zelnode/zelnode.h"
 #include "zelnode/obfuscation.h"
 #include "zelnode/activezelnode.h"
+#include "snapshot/snapshotdb.h"
 
 #ifdef ENABLE_WALLET
 #include "key_io.h"
@@ -244,6 +245,8 @@ void Shutdown()
         pblocktree = NULL;
         delete pFluxnodeDB;
         pFluxnodeDB = NULL;
+        delete pSnapshotDB;
+        pSnapshotDB = NULL;
     }
 #ifdef ENABLE_WALLET
     if (pwalletMain)
@@ -1502,9 +1505,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pcoinscatcher;
                 delete pblocktree;
                 delete pFluxnodeDB;
+                delete pSnapshotDB;
 
                 /** Fluxnode Database */
                 pFluxnodeDB = new CDeterministicFluxnodeDB(0, false, fReindex);
+                pSnapshotDB = new CSnapshotDB(0, false, false);
 
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
                 pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <atomic>
 
+#include "snapshot/snapshotdb.h"
 #include "zelnode/zelnodecachedb.h"
 #include "zelnode/obfuscation.h"
 #include "zelnode/activezelnode.h"
@@ -593,6 +594,8 @@ CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& loc
 CCoinsViewCache *pcoinsTip = NULL;
 CBlockTreeDB *pblocktree = NULL;
 CDeterministicFluxnodeDB* pFluxnodeDB = NULL;
+CSnapshotDB* pSnapshotDB = NULL;
+
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -4175,6 +4178,8 @@ static bool ActivateBestChainStep(CValidationState& state, const CChainParams& c
     mempool.removeWithoutBranchId(
         CurrentEpochBranchId(chainActive.Tip()->nHeight + 1, chainparams.GetConsensus()));
     mempool.check(pcoinsTip);
+
+    CheckForSnapshot(pcoinsTip);
 
     // Callbacks/notifications for a new best chain.
     if (fInvalidFound)

--- a/src/main.h
+++ b/src/main.h
@@ -43,6 +43,7 @@
 #include <boost/unordered_map.hpp>
 
 #include "zelnode/zelnodecachedb.h"
+#include "snapshot/snapshotdb.h"
 
 class CBlockIndex;
 class CBlockTreeDB;
@@ -535,6 +536,9 @@ extern CBlockTreeDB *pblocktree;
 
 /** Global variable that points to the fluxnode database (protected by cs_main) */
 extern CDeterministicFluxnodeDB* pFluxnodeDB;
+
+/** Global variable that points to the snapshot database (protected by cs_main) */
+extern CSnapshotDB* pSnapshotDB;
 
 /**
  * Return the spend height, which is one more than the inputs.GetBestBlock().

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -143,7 +143,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_getpaymentdisclosure", 1},
     { "z_getpaymentdisclosure", 2},
     { "z_setmigration", 0},
-    { "spork", 1}
+    { "spork", 1},
+    { "printsnapshot", 0}
 };
 
 class CRPCConvertTable

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -460,7 +460,7 @@ UniValue printsnapshot(const UniValue& params, bool fHelp)
                 "printsnapshot \"time\" \n"
                 "\nPrints a snapshot prettylike\n"
                 "\nArguments:\n"
-                "1. \"time\"    (string, required) The Flux address to use for the signature.\n"
+                "1. \"timeorheight\"    (string, required) The timestamp or blockheight that the snapshot was created at\n"
                 "\nResult:\n"
                 "[\n"
                 "address : balance,\n"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -453,6 +453,28 @@ UniValue verifymessage(const UniValue& params, bool fHelp)
     return (pubkey.GetID() == *keyID);
 }
 
+UniValue printsnapshot(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+                "printsnapshot \"time\" \n"
+                "\nPrints a snapshot prettylike\n"
+                "\nArguments:\n"
+                "1. \"time\"    (string, required) The Flux address to use for the signature.\n"
+                "\nResult:\n"
+                "[\n"
+                "address : balance,\n"
+                "...\n"
+                "]\n"
+                "\nExamples:\n"
+                + HelpExampleCli("printsnapshot", "256884524")
+                + HelpExampleRpc("printsnapshot", "256884524")
+        );
+
+    int64_t nTime = params[0].get_int64();
+    return PrettyPrintSnapshot(nTime);
+}
+
 UniValue setmocktime(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
@@ -1118,6 +1140,8 @@ static const CRPCCommand commands[] =
     { "util",               "z_validateaddress",      &z_validateaddress,      true  }, /* uses wallet if enabled */
     { "util",               "createmultisig",         &createmultisig,         true  },
     { "util",               "verifymessage",          &verifymessage,          true  },
+
+    { "util",               "printsnapshot",          &printsnapshot,          true  },
 
     // START insightexplorer
     /* Address index */

--- a/src/snapshot/snapshotdb.cpp
+++ b/src/snapshot/snapshotdb.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2022 The Flux Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "snapshotdb.h"
+#include <boost/filesystem.hpp>
+#include "univalue.h"
+#include "rpc/server.h"
+#include "main.h"
+
+static const char DB_SNAPSHOT = 's';
+
+CSnapshotDB::CSnapshotDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetDataDir() / "snapshots", nCacheSize, fMemory, fWipe) {}
+
+
+bool CSnapshotDB::WriteFluxSnapshot(const CSnapshot &snapshot)
+{
+    LogPrint("snapshot", "Wrote snapshot to database at height %d\n", snapshot.nActualSnapshotHeight);
+    return Write(std::make_pair(DB_SNAPSHOT, snapshot.nSnapshotTime), snapshot);
+}
+
+bool CSnapshotDB::ReadFluxSnapshot(const int64_t& nTime, CSnapshot &snapshot)
+{
+    LogPrint("snapshot", "Reading snapshot from database at time %d\n", nTime);
+    return Read(std::make_pair(DB_SNAPSHOT, nTime), snapshot);
+}
+
+UniValue PrettyPrintSnapshot(const int64_t& nTime)
+{
+    CSnapshot snapshot;
+    snapshot.nSnapshotTime = nTime;
+
+    if (pSnapshotDB && pSnapshotDB->ReadFluxSnapshot(nTime, snapshot)) {
+        UniValue data(UniValue::VOBJ);
+
+        data.pushKV("timegiven", nTime);
+        data.pushKV("height", snapshot.nActualSnapshotHeight);
+
+        UniValue balances(UniValue::VOBJ);
+        for (const auto& pair: snapshot.mapBalances) {
+            balances.pushKV(pair.first, ValueFromAmount(pair.second));
+        }
+
+        data.pushKV("balances", balances);
+
+        return data;
+    }
+
+    return NullUniValue;
+}
+
+void CheckForSnapshot(CCoinsViewCache* coinsview)
+{
+    if (!pSnapshotDB) {
+        return;
+    }
+
+    // Check if snapshot timestamp was set
+    int64_t nSnapshotTime = GetArg("-snapshot", 0);
+    if (nSnapshotTime <= 0) {
+        return;
+    }
+
+    // Check if snapshot at this timestamp is already completed
+    if (pSnapshotDB->Exists(std::make_pair(DB_SNAPSHOT, nSnapshotTime))) {
+        return;
+    }
+
+    {
+        // Locking as we are accessing chainActive
+        LOCK(cs_main);
+        int64_t tipTime = chainActive.Tip()->nTime;
+        int64_t nPrevTime = chainActive[chainActive.Height() - 1]->nTime;
+
+        // The snap shot time must be greater than the block two blocks ago but less that the current tip
+        if (nSnapshotTime < nPrevTime) {
+            return;
+        }
+
+        if (nSnapshotTime > tipTime) {
+            return;
+        }
+    }
+
+    // If you made it this far, create the snapshot
+    CreateSnapshot(nSnapshotTime, coinsview);
+}
+
+void CreateSnapshot(const int64_t& nTime, CCoinsViewCache* coinsview)
+{
+
+    CSnapshot snapshot;
+    snapshot.nSnapshotTime = nTime;
+
+    // Set the block height
+    {
+        LOCK(cs_main);
+        snapshot.nActualSnapshotHeight = chainActive.Height();
+    }
+
+    // Flush the state to before accessing the coins database.
+    // This will ensure all data is as valid as it can be
+    FlushStateToDisk();
+
+    {
+        LOCK(cs_main);
+        coinsview->GetAllBalances(snapshot.mapBalances);
+    }
+
+    if(pSnapshotDB->WriteFluxSnapshot(snapshot)) {
+        LogPrintf("Wrote snapshot to db");
+    } else {
+        LogPrintf("Failed to write snapshot to db");
+    }
+}

--- a/src/snapshot/snapshotdb.h
+++ b/src/snapshot/snapshotdb.h
@@ -24,25 +24,25 @@ public:
 
     void SetNull()
     {
-        nSnapshotTime = 0;
+        nSnapshotTimeOrHeight = 0;
         nActualSnapshotHeight = 0;
         mapBalances.clear();
     }
 
-    int64_t nSnapshotTime;
+    int64_t nSnapshotTimeOrHeight;
     int32_t nActualSnapshotHeight;
     std::map<std::string,CAmount> mapBalances;
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(nSnapshotTime);
+        READWRITE(nSnapshotTimeOrHeight);
         READWRITE(nActualSnapshotHeight);
         READWRITE(mapBalances);
     }
 };
 
-UniValue PrettyPrintSnapshot(const int64_t& nTime);
+UniValue PrettyPrintSnapshot(const int64_t& nTimeOrHeight);
 void CheckForSnapshot(CCoinsViewCache *);
 void CreateSnapshot(const int64_t& nTime, CCoinsViewCache *);
 

--- a/src/snapshot/snapshotdb.h
+++ b/src/snapshot/snapshotdb.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 The Flux Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ZELCASH_CSNAPSHOTDB_H
+#define ZELCASH_CSNAPSHOTDB_H
+
+#include "dbwrapper.h"
+#include <boost/filesystem/path.hpp>
+#include <amount.h>
+
+class UniValue;
+class CCoinsViewCache;
+
+// A Snapshot will be created after the first block that is mined after the given timestamp.
+class CSnapshot
+{
+
+public:
+    CSnapshot()
+    {
+        SetNull();
+    }
+
+    void SetNull()
+    {
+        nSnapshotTime = 0;
+        nActualSnapshotHeight = 0;
+        mapBalances.clear();
+    }
+
+    int64_t nSnapshotTime;
+    int32_t nActualSnapshotHeight;
+    std::map<std::string,CAmount> mapBalances;
+
+    ADD_SERIALIZE_METHODS;
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(nSnapshotTime);
+        READWRITE(nActualSnapshotHeight);
+        READWRITE(mapBalances);
+    }
+};
+
+UniValue PrettyPrintSnapshot(const int64_t& nTime);
+void CheckForSnapshot(CCoinsViewCache *);
+void CreateSnapshot(const int64_t& nTime, CCoinsViewCache *);
+
+class CSnapshotDB : public CDBWrapper
+{
+
+public:
+    CSnapshotDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+
+private:
+    CSnapshotDB(const CSnapshotDB&);
+    void operator=(const CSnapshotDB&);
+
+public:
+    bool WriteFluxSnapshot(const CSnapshot& snapshot);
+    bool ReadFluxSnapshot(const int64_t& nTime, CSnapshot &snapshot);
+};
+
+
+#endif //ZELCASH_CSNAPSHOTDB_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -96,6 +96,7 @@ public:
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers);
     bool GetStats(CCoinsStats &stats) const;
+    bool GetAllBalances(std::map<std::string, CAmount>& mapBalances) const;
 };
 
 /** Access to the block database (blocks/index/) */

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -506,6 +506,10 @@ public:
     bool GetStats(CCoinsStats &stats) const {
         return false;
     }
+
+    bool GetAllBalances(std::map<std::string, CAmount> &mapBalances) const {
+        return false;
+    }
 };
 
 double benchmark_connectblock_slow()


### PR DESCRIPTION
This code adds a new database in a new folder /snapshots
New RPC call **printsnapshot \<timestamp\>**

To take a snapshot add the following to the .conf 
snapshot=\<timestamp\>

or run fluxd with the flag 
-snapshot=\<timestamp\>

The snapshot will be taken on the block height of the next block that comes after the given \<timestamp\>

Example: 
snapshot=1649783322 which is (Tue Apr 12 2022 17:08:42 UTC)

Give the following snapshot: 
` {
  "nTime": 1649783322,
  "height": 1097936,
  "balances": {
    "t1Hsc324kffbMX2ehmSMHLB2JBxLn8E76EL": 142.57974269,
    "t1HscB7BresscYibF5hiAzotugpnEwAgxki": 0.00200000,
    "t1HscB7DDYqKHLXWipvZ7pmmxE1VFPXW5b4": 0.00185900,
    "t1HscCUEEMpGtdQzXedWwuc614U7wHiG4JQ": 0.00080000,
    ............
    ............
}`

The height 1097936 - has the timestamp of 1649783340, which is 18 seconds after the given timestamp. 


To produce the snapshot into a readable format. Call the following rpccall

`printsnapshot  <timestamp>  >> snapshot.json`


Then open snapshot.json to view the snapshot data









