### PR TITLE
Fix rename on existing configuration flag

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1909,7 +1909,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
         std::string strHash = GetArg("-zelnodeoutpoint", "");
         uint256 hash = uint256S(strHash);
-        int index = GetArg("-fluxnodeindex", -1);
+        int index = GetArg("-zelnodeindex", -1);
 
         fluxnodeOutPoint = COutPoint(hash, index);
 


### PR DESCRIPTION
- This was accidently changed during the rename to flux. 

However because this is a change that would break already existing nodes that are using zelnodeindex in the flux.conf we don't want to change it