### PR TITLE
Updated Zel/Zelcash to Flux in comments only. Some old URLs also updated.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please read [our Development Guidelines](https://zel.gitbook.io/zelcurrency/development-guidelines).
+Please visit [our Github](https://github.com/runonflux).

--- a/src/amount.cpp
+++ b/src/amount.cpp
@@ -8,7 +8,7 @@
 
 #include "tinyformat.h"
 
-const std::string CURRENCY_UNIT = "ZEL";
+const std::string CURRENCY_UNIT = "ZEL"; // "ZEL" is now known as "FLUX"
 
 CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nSize)
 {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -86,7 +86,7 @@ class CMainParams : public CChainParams {
 public:
     CMainParams() {
         strNetworkID = "main";
-        strCurrencyUnits = "ZEL";
+        strCurrencyUnits = "ZEL"; // "ZEL" is now known as "FLUX"
 	    bip44CoinType = 19167;
         consensus.fCoinbaseMustBeProtected = true;
         consensus.nSubsidySlowStartInterval = 5000;

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -100,7 +100,7 @@ TEST(TransactionBuilder, TransparentToSapling)
     auto pk = *ivk.address(d);
 
     // Create a shielding transaction from transparent to Sapling
-    // 0.0005 t-ZEL in, 0.0004 z-ZEL out, 0.0001 t-ZEL fee
+    // 0.0005 t-FLUX in, 0.0004 z-FLUX out, 0.0001 t-FLUX fee
     auto builder = TransactionBuilder(consensusParams, 1, expiryDelta, &keystore);
     builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000);
     builder.AddSaplingOutput(fvk_from.ovk, pk, 40000, {});
@@ -132,7 +132,7 @@ TEST(TransactionBuilder, SaplingToSapling) {
     auto testNote = GetTestSaplingNote(pa, 40000);
     
     // Create a Sapling-only transaction
-    // 0.0004 z-ZEL in, 0.00025 z-ZEL out, 0.0001 t-ZEL fee, 0.00005 z-ZEL change
+    // 0.0004 z-FLUX in, 0.00025 z-FLUX out, 0.0001 t-FLUX fee, 0.00005 z-FLUX change
     auto builder = TransactionBuilder(consensusParams, 2, expiryDelta);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
 
@@ -171,9 +171,9 @@ TEST(TransactionBuilder, SaplingToSprout) {
     auto sproutAddr = sproutSk.address();
 
     // Create a Sapling-to-Sprout transaction (reusing the note from above)
-    // - 0.0004 Sapling-ZEL in      - 0.00025 Sprout-ZEL out
-    //                              - 0.00005 Sapling-ZEL change
-    //                              - 0.0001 t-ZEL fee
+    // - 0.0004 Sapling-FLUX in     - 0.00025 Sprout-FLUX out
+    //                              - 0.00005 Sapling-FLUX change
+    //                              - 0.0001 t-FLUX fee
     auto builder = TransactionBuilder(consensusParams, 2, expiryDelta, nullptr, params);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSproutOutput(sproutAddr, 25000);
@@ -221,11 +221,11 @@ TEST(TransactionBuilder, SproutToSproutAndSapling) {
     CCoinsViewCache view(&fakeDB);
 
     // Create a Sprout-to-[Sprout-and-Sapling] transaction
-    // - 0.00025 Sprout-ZEL in      - 0.00006 Sprout-ZEL out
-    //                              - 0.00004 Sprout-ZEL out
-    //                              - 0.00005 Sprout-ZEL change
-    //                              - 0.00005 Sapling-ZEL out
-    //                              - 0.00005 t-ZEL fee
+    // - 0.00025 Sprout-FLUX in     - 0.00006 Sprout-FLUX out
+    //                              - 0.00004 Sprout-FLUX out
+    //                              - 0.00005 Sprout-FLUX change
+    //                              - 0.00005 Sapling-FLUX out
+    //                              - 0.00005 t-FLUX fee
     auto builder = TransactionBuilder(consensusParams, 2, expiryDelta, nullptr, params, &view);
     builder.SetFee(5000);
     builder.AddSproutInput(sproutSk, sproutNote, sproutWitness);
@@ -318,19 +318,19 @@ TEST(TransactionBuilder, FailsWithNegativeChange)
     auto testNote = GetTestSaplingNote(pa, 59999);
 
     // Fail if there is only a Sapling output
-    // 0.0005 z-ZEL out, 0.0001 t-ZEL fee
+    // 0.0005 z-FLUX out, 0.0001 t-FLUX fee
     auto builder = TransactionBuilder(consensusParams, 1, expiryDelta);
     builder.AddSaplingOutput(fvk.ovk, pa, 50000, {});
     EXPECT_EQ("Change cannot be negative", builder.Build().GetError());
 
     // Fail if there is only a transparent output
-    // 0.0005 t-ZEL out, 0.0001 t-ZEL fee
+    // 0.0005 t-FLUX out, 0.0001 t-FLUX fee
     builder = TransactionBuilder(consensusParams, 1, expiryDelta, &keystore);
     builder.AddTransparentOutput(taddr, 50000);
     EXPECT_EQ("Change cannot be negative", builder.Build().GetError());
 
     // Fails if there is insufficient input
-    // 0.0005 t-ZEL out, 0.0001 t-ZEL fee, 0.00059999 z-ZEL in
+    // 0.0005 t-FLUX out, 0.0001 t-FLUX fee, 0.00059999 z-FLUX in
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     EXPECT_EQ("Change cannot be negative", builder.Build().GetError());
 

--- a/src/gtest/test_txid.cpp
+++ b/src/gtest/test_txid.cpp
@@ -15,7 +15,7 @@
  Test that removing #1144 succeeded by verifying the hash of a transaction is over the entire serialized form.
  */
 TEST(txid_tests, check_txid_and_hash_are_same) {
-    // Random zelcash transaction aacaa62d40fcdd9192ed35ea9df31660ccf7f6c60566530faaa444fb5d0d410e
+    // Random flux transaction aacaa62d40fcdd9192ed35ea9df31660ccf7f6c60566530faaa444fb5d0d410e
     CTransaction tx;
     CDataStream stream(ParseHex("01000000015ad78be5497476bbf84869d8156761ca850b6e82e48ad1315069a3726516a3d1010000006b483045022100ba5e90204e83c5f961b67c6232c1cc6c360afd36d43fcfae0de7af2e75f4cda7022012fec415a12048dbb70511fda6195b090b56735232281dc1144409833a092edc012102c322382e17c9ed4f47183f219cc5dd7853f939fb8eebae3c943622e0abf8d5e5feffffff0280969800000000001976a91430271a250e92135ce0db0783ebb63aaeb58e47f988acd694693a000000001976a9145f0d00adba6489150808feb4108d7be582cbb2e188ac0a000000"), SER_DISK, CLIENT_VERSION);
     stream >> tx;
@@ -25,7 +25,7 @@ TEST(txid_tests, check_txid_and_hash_are_same) {
 }
 
 TEST(txid_tests, check_txid_and_hash_are_same_coinbase) {
-    // Random zelcash coinbase transaction 6041357de59ba64959d1b60f93de24dfe5ea1e26ed9e8a73d35b225a1845bad5
+    // Random flux coinbase transaction 6041357de59ba64959d1b60f93de24dfe5ea1e26ed9e8a73d35b225a1845bad5
     CTransaction tx;
     CDataStream stream(ParseHex("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff03530101ffffffff02f049020000000000232102f2df427fd4f76552ed0e86b17da8cf9b07754ea23ddc05799410a4a3a5d806ccac7c9200000000000017a9146708e6670db0b950dac68031025cc5b63213a4918700000000"), SER_DISK, CLIENT_VERSION);
     stream >> tx;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1253,7 +1253,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         threadGroup.create_thread(&ThreadShowMetricsScreen);
     }
 
-    // Initialize Zelcash circuit parameters
+    // Initialize Flux circuit parameters ("ZC" in function name refers to Zelcash)
     ZC_LoadParams(chainparams);
 
     /* Start the RPC server already.  It will be started in "warmup" mode

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4798,7 +4798,7 @@ bool ContextualCheckBlock(
     }
 
     // Enforce BIP 34 rule that the coinbase starts with serialized block height.
-    // In Zelcash this has been enforced since launch, except that the genesis
+    // In Flux this has been enforced since launch, except that the genesis
     // block didn't include the height in the coinbase (see Zcash protocol spec
     // section '6.8 Bitcoin Improvement Proposals').
     // Needs to be at least > 16 to satisfy second condition.

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -74,7 +74,7 @@ enum {
     NODE_NETWORK = (1 << 0),
 
     // NODE_BLOOM means the node is capable and willing to handle bloom-filtered connections.
-    // Zelcash nodes used to support this by default, without advertising this bit,
+    // Flux nodes used to support this by default, without advertising this bit,
     // but no longer do as of protocol version 170004 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
 

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -27,12 +27,12 @@ bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchS
     if (vchSig.size() == 0) {
         return false;
     }
-    /* Zelcash, unlike Bitcoin, has always enforced strict DER signatures. */
+    /* Flux, unlike Bitcoin, has always enforced strict DER signatures. */
     if (!secp256k1_ecdsa_signature_parse_der(secp256k1_context_verify, &sig, &vchSig[0], vchSig.size())) {
         return false;
     }
     /* libsecp256k1's ECDSA verification requires lower-S signatures, which have
-     * not historically been enforced in Bitcoin or Zelcash, so normalize them first. */
+     * not historically been enforced in Bitcoin or Flux, so normalize them first. */
     secp256k1_ecdsa_signature_normalize(secp256k1_context_verify, &sig, &sig);
     return secp256k1_ecdsa_verify(secp256k1_context_verify, &sig, hash.begin(), &pubkey);
 }

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -20,7 +20,7 @@ void RegisterMiscRPCCommands(CRPCTable &tableRPC);
 void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 /** Register raw transaction RPC commands */
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
-/** Register zelnode RPC commands */
+/** Register Fluxnode RPC commands */
 void RegisterFluxnodeRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &tableRPC)

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -46,7 +46,7 @@ enum
     SCRIPT_VERIFY_STRICTENC = (1U << 1),
 
     // Passing a non-strict-DER signature to a checksig operation causes script failure (softfork safe, BIP62 rule 1)
-    // In Zelcash this is required, and validation of non-strict-DER signatures is not implemented.
+    // In Flux this is required, and validation of non-strict-DER signatures is not implemented.
     //SCRIPT_VERIFY_DERSIG    = (1U << 2),
 
     // Passing a non-strict-DER signature or one with S > order/2 to a checksig operation causes script failure

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -78,7 +78,7 @@ void ThreadSendAlert()
     CAlert alert;
     alert.nRelayUntil   = GetTime() + 15 * 60;
     alert.nExpiration   = GetTime() + 12 * 30 * 24 * 60 * 60;
-    alert.nID           = 1006;  // use https://github.com/zelcash/zelcash/wiki/specification#assigned-numbers to keep track of alert IDs
+    alert.nID           = 1006;  // use https://github.com/RunOnFlux/fluxd/wiki/specification#assigned-numbers to keep track of alert IDs
     alert.nCancel       = 1005;  // cancels previous messages up to this ID number
 
     // These versions are protocol versions

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
     }
     // Changing the block interval from 10 to 2.5 minutes causes truncation
     // effects to occur earlier (from the 9th halving interval instead of the
-    // 11th), decreasing the total monetary supply by 0.0693 ZEL. If the
+    // 11th), decreasing the total monetary supply by 0.0693 FLUX. If the
     // transaction output field is widened, this discrepancy will become smaller
     // or disappear entirely.
     //BOOST_CHECK_EQUAL(nSum, 2099999997690000ULL);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -456,7 +456,7 @@ static std::string FormatException(const std::exception* pex, const char* pszThr
     char pszModule[MAX_PATH] = "";
     GetModuleFileNameA(NULL, pszModule, sizeof(pszModule));
 #else
-    const char* pszModule = "Zelcash";
+    const char* pszModule = "Zelcash"; // "Zelcash" is now known as "Flux"
 #endif
     if (pex)
         return strprintf(

--- a/src/wallet/asyncrpcoperation_saplingmigration.cpp
+++ b/src/wallet/asyncrpcoperation_saplingmigration.cpp
@@ -87,7 +87,7 @@ bool AsyncRPCOperation_saplingmigration::main_impl() {
     for (const SproutNoteEntry& sproutEntry : sproutEntries) {
         availableFunds += sproutEntry.note.value();
     }
-    // If the remaining amount to be migrated is less than 0.01 ZEL, end the migration.
+    // If the remaining amount to be migrated is less than 0.01 FLUX, end the migration.
     if (availableFunds < CENT) {
         LogPrint("zrpcunsafe", "%s: Available Sprout balance (%s) less than required minimum (%s). Stopping.\n",
             getId(), FormatMoney(availableFunds), FormatMoney(CENT));
@@ -141,8 +141,8 @@ bool AsyncRPCOperation_saplingmigration::main_impl() {
             pwalletMain->GetSproutNoteWitnesses(vOutPoints, vInputWitnesses, inputAnchor);
             builder.AddSproutInput(sproutSk, sproutEntry.note, vInputWitnesses[0].get());
         }
-        // The amount chosen *includes* the 0.0001 ZEL fee for this transaction, i.e.
-        // the value of the Sapling output will be 0.0001 ZEL less.
+        // The amount chosen *includes* the 0.0001 FLUX fee for this transaction, i.e.
+        // the value of the Sapling output will be 0.0001 FLUX less.
         builder.SetFee(FEE);
         builder.AddSaplingOutput(ovkForShieldingFromTaddr(seed), migrationDestAddress, amountToSend - FEE);
         CTransaction tx = builder.Build().GetTxOrThrow();

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -1932,7 +1932,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
 
     // Generate shielding tx from transparent to Sapling
-    // 0.0005 t-ZEL in, 0.0004 z-ZEL out, 0.0001 t-ZEL fee
+    // 0.0005 t-FLUX in, 0.0004 z-FLUX out, 0.0001 t-FLUX fee
     auto builder = TransactionBuilder(consensusParams, 1, expiryDelta, &keystore);
     builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000);
     builder.AddSaplingOutput(fvk.ovk, pk, 40000, {});
@@ -1987,7 +1987,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     auto witness = saplingTree.witness();
 
     // Create a Sapling-only transaction
-    // 0.0004 z-ZEL in, 0.00025 z-ZEL out, 0.0001 t-ZEL fee, 0.00005 z-ZEL change
+    // 0.0004 z-FLUX in, 0.00025 z-FLUX out, 0.0001 t-FLUX fee, 0.00005 z-FLUX change
     auto builder2 = TransactionBuilder(consensusParams, 2, expiryDelta);
     builder2.AddSaplingSpend(expsk, note, anchor, witness);
     builder2.AddSaplingOutput(fvk.ovk, pk, 25000, {});

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -90,9 +90,9 @@ enum WalletFeature
 
 enum AvailableCoinsType {
     ALL_COINS = 1,
-    ONLY_CUMULUS = 2,   // find zelnode outputs including locked ones (use with caution) for 10000
-    ONLY_NIMBUS = 3,   // find zelnode outputs including locked ones (use with caution) for 25000
-    ONLY_STRATUS = 4,  // find zelnode outputs including locked ones (use with caution) for 100000
+    ONLY_CUMULUS = 2,   // find Fluxnode outputs including locked ones (use with caution) for 10000
+    ONLY_NIMBUS = 3,   // find Fluxnode outputs including locked ones (use with caution) for 25000
+    ONLY_STRATUS = 4,  // find Fluxnode outputs including locked ones (use with caution) for 100000
     ALL_FLUXNODE = 5
 };
 
@@ -1333,7 +1333,7 @@ public:
 
 
     /** Fluxnode Additions */
-    /// Get 10000, 25000, 100000, ZEL output and keys which can be used for the Fluxnode
+    /// Get 10000, 25000, 100000, FLUX output and keys which can be used for the Fluxnode
     bool GetFluxnodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash = "", std::string strOutputIndex = "");
     /// Extract txin information and keys from output
     bool GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubKeyRet, CKey& keyRet);

--- a/src/zelcash/NoteEncryption.hpp
+++ b/src/zelcash/NoteEncryption.hpp
@@ -3,8 +3,8 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 /*
-See the Zelcash protocol specification for more information.
-https://github.com/zelcash/zips/blob/master/protocol/protocol.pdf
+See the Flux white paper for more information.
+https://fluxwhitepaper.app.runonflux.io/?_gl=1*egc2l8*_ga*NTM5NTY4MDM1LjE2Mjg5NDE2NDY.*_ga_M3VPBDLWV7*MTY1OTE3NjIxOC43NC4wLjE2NTkxNzYyMTguNjA.
 */
 
 #ifndef ZC_NOTE_ENCRYPTION_H_

--- a/src/zelcash/prf.h
+++ b/src/zelcash/prf.h
@@ -3,7 +3,7 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 /*
-Zelcash uses SHA256Compress as a PRF for various components
+Flux uses SHA256Compress as a PRF for various components
 within the zkSNARK circuit.
 */
 

--- a/src/zelnode/activezelnode.h
+++ b/src/zelnode/activezelnode.h
@@ -26,11 +26,11 @@ private:
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
 
-    /// Get ZEL input that can be used for the Fluxnode
+    /// Get FLUX input that can be used for the Fluxnode
     bool GetFluxNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey, std::string strTxHash, std::string strOutputIndex, std::string& errorMessage);
     bool GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
 
-    /// Get 10000 ZEL input that can be used for the Fluxnode
+    /// Get 10000 FLUX input that can be used for the Fluxnode
     bool GetFluxNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
 
 public:
@@ -56,7 +56,7 @@ public:
 
     vector<std::pair<COutput, CAmount>> SelectCoinsFluxnode();
 
-    //Manage my active deterministic zelnode
+    // Manage my active deterministic Fluxnode
     void ManageDeterministricFluxnode();
 
     bool BuildDeterministicStartTx(std::string strKey, std::string strTxHash, std::string strOutputIndex, std::string& errorMessage, CMutableTransaction& mutTransaction);


### PR DESCRIPTION
Updated references to "Zel"/"Zelcash"/"Zelnode" to "Flux"/"Fluxnode". This has been done in comments only. Some old/broken URLs also updated.

ReadMe file not updated in this PR but can be done in a separate PR if required.