### PR TITLE
Updated ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,34 @@
-# Zel 6.0.0
-[![Build Status](https://travis-ci.com/zelcash/zelcash.svg?branch=master)](https://travis-ci.com/zelcash/zelcash)
-<img align="right" height=112 width=562 src="doc/imgs/kamata.png">
+# Flux 6.0.0
+[![Build Status](https://app.travis-ci.com/RunOnFlux/fluxd.svg?branch=master)](https://app.travis-ci.com/github/RunOnFlux/fluxd)
 
-## Mandatory Upgrade to at least version 4.0.0
-
-What is Zel?
+What is Flux?
 --------------
 
-[Zel](https://zel.network/) is a fork of 2.1.0-1 Zcash aiming to provide a decentralized development platform via ZelFlux, ZelNodes, ZelCore and more.
+[Flux](https://runonflux.io/) (formerly known as Zel) is a fork of 2.1.0-1 Zcash aiming to provide a decentralized development platform via FluxOS, FluxNodes, ZelCore and more.
 
-Zel is PoW and "ASIC resistant" with ZelHash (Modified Equihash 125,4) with the personalisation string ZelProof and utilises the LWMA3 difficulty algorithm.
-The latest Kamata network upgrade activates on block 558,000 - around the 18th of March 2020. Kamata brings ZelFlux, ZelBenchd, Determenistic ZelNodes and more.
-
-
-<p align="center">
-  <img src="doc/imgs/kamata-mandatory.png" height=500 >
-</p>
+Flux is PoW and "ASIC resistant" with ZelHash (Modified Equihash 125,4) with the personalisation string ZelProof and utilises the LWMA3 difficulty algorithm.
 
 ## :rocket: Getting Started
 
-Please see our [user guide](https://zel.gitbook.io/zeldocs/) for any and all info.
+Please see our [wiki](https://wiki.runonflux.io/) for any and all info.
 
-To setup a Zelnode please follow this[script](https://github.com/zelcash/deterministic-zelnode-script/) and wiki.
+To setup a FluxNode please follow this [guide](https://medium.com/@mmalik4/flux-light-node-setup-as-easy-as-it-gets-833f17c73dbb) and this [video guide](https://www.youtube.com/watch?v=KYWUXrKP9do).
+
+### Building
+
+Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon).
+
+If you have the dependencies you can build Flux Daemon from source by running:
+
+```
+./zcutil/build.sh -j$(nproc)
+```
 
 ### Need Help?
 
 * :blue_book: See the documentation at the [Zel GitBook](https://zel.gitbook.io/zelcurrency/installing-zel-daemon)
   for help and more information.
-* :mag: Join us on [Discord.io/Zel](https://discord.io/zel) for support and to join the community conversation. 
-
-### Building
-
-Dependencies and build instructions for all supported platforms: [Zel GitBook](https://zel.gitbook.io/zelcurrency/installing-zel-daemon)
-
-If you have the dependencies you can build Zel from source by running:
-
-```
-./zcutil/build.sh -j$(nproc)
-```
+* :mag: Join us on [Discord.io/RunOnFlux](https://discord.io/runonflux) for support and to join the community conversation. 
 
 #### :lock: Security Warnings
 


### PR DESCRIPTION
Updated ReadMe with "Zel" updated to "Flux", old images removed and old links updated. The existing "Zel" [daemon build and installation guide](https://zel.gitbook.io/zelcurrency/installing-zel-daemon) remains as the content is still relevant and I don't think that there is any updated "Flux" version of this yet.