### PR TITLE
Support for bool

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -139,6 +139,10 @@ public:
         UniValue tmpVal(val_);
         return pushKV(key, tmpVal);
     }
+    bool pushKV(const std::string& key, bool val_) {
+        UniValue tmpVal(val_);
+        return pushKV(key, tmpVal);
+    }
     bool pushKVs(const UniValue& obj);
 
     std::string write(unsigned int prettyIndent = 0,


### PR DESCRIPTION
Between fluxd version 6.0 and 6.1 the output of getblockchaininfo changed from showing a 

pruned: false,

to 

pruned: 0. 

Blockbook doesn't like the integer value so this code allows for booleans to be supported with the pushKV pairing we use for rpc outputs. 