### PR TITLE
Bugfixes for v6.1.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7605,7 +7605,11 @@ CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Para
     return mtx;
 }
 
-unsigned int GetMaxReorgDepth(const int64_t nHeight) {
+/** This must always be a signed int. Because when comparing it to the chainActive.Height()
+we need to compare similar types or i < j will not function correctly
+You must compare (int < int) because (int < unsigned int) can give incorrectly results
+*/
+int64_t GetMaxReorgDepth(const int64_t nHeight) {
     if (nHeight > MAX_REORG_LENGTH_UPDATED_HEIGHT) {
         return MAX_REORG_LENGTH_UPDATED;
     }

--- a/src/main.h
+++ b/src/main.h
@@ -265,7 +265,7 @@ CAmount GetFluxnodeSubsidy(int nHeight, const CAmount& blockValue, int nNodeTier
 CAmount GetExchangeFundAmount(int nHeight, const Consensus::Params& consensusParams);
 CAmount GetFoundationFundAmount(int nHeight, const Consensus::Params& consensusParams);
 bool IsSwapPoolInterval(const int64_t nHeight);
-unsigned int GetMaxReorgDepth(const int64_t nHeight);
+int64_t GetMaxReorgDepth(const int64_t nHeight);
 
 /**
  * Prune block and undo files (blk???.dat and undo???.dat) so that the disk space used is less than a user-defined target.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -746,11 +746,15 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         CTxDestination dest;
         ExtractDestination(payout.second.first, dest);
 
-        result.pushKV(std::string(start + "_fluxnode_address"), EncodeDestination(dest));
-        result.pushKV(std::string(start + "_fluxlnode_payout"), payout.second.second);
-
+        /** Only use named (cumulus, nimbus, stratus) when using fluxnode naming scheme */
         result.pushKV(std::string(start_rename + "_fluxnode_address"), EncodeDestination(dest));
         result.pushKV(std::string(start_rename + "_fluxnode_payout"), payout.second.second);
+
+        /** We must keep zelnode here for backwards capabilities so pools don't break when they upgrade to latest releases */
+        result.pushKV(std::string(start + "_zelnode_address"), EncodeDestination(dest));
+        result.pushKV(std::string(start + "_zelnode_payout"), payout.second.second);
+        result.pushKV(std::string(start_rename + "_zelnode_address"), EncodeDestination(dest));
+        result.pushKV(std::string(start_rename + "_zelnode_payout"), payout.second.second);
     }
 
     // These should never be on the same block. So to keep it clean for pools we will use the same


### PR DESCRIPTION
- Add backwards capabilities for pools using gbt with older "zelnode" vernacular
- Fix type for max reorg method so comparisons are made correctly. 