### PR TITLE
Cache Fluxnode list

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -165,6 +165,7 @@ BITCOIN_CORE_H = \
   pubkey.h \
   random.h \
   reverselock.h \
+  rpc/cache.h \
   rpc/client.h \
   rpc/protocol.h \
   rpc/server.h \
@@ -265,6 +266,7 @@ libbitcoin_server_a_SOURCES = \
   pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
+  rpc/cache.cpp \
   rpc/mining.cpp \
   rpc/misc.cpp \
   rpc/net.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1941,10 +1941,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         LOCK(pwalletMain->cs_wallet);
         LogPrintf("Locking Fluxnodes:\n");
         uint256 znTxHash;
-        for (FluxnodeConfig::FluxnodeEntry zne : fluxnodeConfig.getEntries()) {
-            LogPrintf("  %s %s\n", zne.getTxHash(), zne.getOutputIndex());
-            znTxHash.SetHex(zne.getTxHash());
-            COutPoint outpoint = COutPoint(znTxHash, (unsigned int) std::stoul(zne.getOutputIndex().c_str()));
+        for (const auto& entry : fluxnodeConfig.getEntries()) {
+            LogPrintf("  %s %s\n", entry.getTxHash(), entry.getOutputIndex());
+            znTxHash.SetHex(entry.getTxHash());
+            COutPoint outpoint = COutPoint(znTxHash, (unsigned int) std::stoul(entry.getOutputIndex().c_str()));
             pwalletMain->LockCoin(outpoint);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "metrics.h"
 #include "net.h"
 #include "pow.h"
+#include "rpc/cache.h"
 #include "txmempool.h"
 #include "ui_interface.h"
 #include "undo.h"
@@ -3858,6 +3859,7 @@ bool static DisconnectTip(CValidationState &state, const CChainParams& chainpara
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         assert(view.Flush());
         assert(fluxnodeCache.Flush());
+        CRPCFluxnodeCache::ClearFluxnodeListCache();
     }
     LogPrint("bench", "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
     uint256 sproutAnchorAfterDisconnect = pcoinsTip->GetBestAnchor(SPROUT);
@@ -3977,6 +3979,7 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
         assert(view.Flush());
 
         assert(fluxnodeCache.Flush());
+        CRPCFluxnodeCache::ClearFluxnodeListCache();
 
         LogPrint("dfluxnode", "%s : Size of global fluxnodeCache mapStartTxTracker : %u\n", __func__, g_fluxnodeCache.mapStartTxTracker.size());
         LogPrint("dfluxnode", "%s : Size of global fluxnodeCache mapStartTxDOSTrackerTxTracker : %u\n", __func__, g_fluxnodeCache.mapStartTxDOSTracker.size());

--- a/src/rpc/cache.cpp
+++ b/src/rpc/cache.cpp
@@ -1,0 +1,20 @@
+//
+// Created by main on 10/3/23.
+//
+
+#include "cache.h"
+#include <univalue.h>
+
+void CRPCFluxnodeCache::ClearFluxnodeListCache()
+{
+    nHeight = -1;
+    list = NullUniValue;
+    filter = "";
+}
+
+void CRPCFluxnodeCache::SetFluxnodeListCache(int64_t pHeight, UniValue& pList, std::string& pFilter)
+{
+    nHeight = pHeight;
+    list = pList;
+    filter = pFilter;
+}

--- a/src/rpc/cache.h
+++ b/src/rpc/cache.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2018-2022 The Flux Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef FLUX_CACHE_H
+#define FLUX_CACHE_H
+
+#include <string>
+
+class UniValue;
+
+class CRPCFluxnodeCache {
+public:
+    // RPC listfluxnodes
+    static int64_t nHeight;
+    static UniValue list;
+    static std::string filter;
+
+    static void ClearFluxnodeListCache();
+    static void SetFluxnodeListCache(int64_t nHeight, UniValue& list, std::string& filter);
+
+};
+
+
+#endif //FLUX_CACHE_H

--- a/src/rpc/fluxnode.cpp
+++ b/src/rpc/fluxnode.cpp
@@ -429,10 +429,10 @@ UniValue startfluxnode(const UniValue& params, bool fHelp, string cmdname)
 
         UniValue resultsObj(UniValue::VARR);
 
-        for (FluxnodeConfig::FluxnodeEntry zne : fluxnodeConfig.getEntries()) {
+        for (const auto& entry : fluxnodeConfig.getEntries()) {
             UniValue fluxnodeEntry(UniValue::VOBJ);
 
-            if (fAlias && zne.getAlias() == alias) {
+            if (fAlias && entry.getAlias() == alias) {
                 found = true;
             } else if (fAlias) {
                 continue;
@@ -442,11 +442,11 @@ UniValue startfluxnode(const UniValue& params, bool fHelp, string cmdname)
             CMutableTransaction mutTransaction;
 
             int32_t index;
-            zne.castOutputIndex(index);
-            COutPoint outpoint = COutPoint(uint256S(zne.getTxHash()), index);
+            entry.castOutputIndex(index);
+            COutPoint outpoint = COutPoint(uint256S(entry.getTxHash()), index);
 
             fluxnodeEntry.push_back(Pair("outpoint", outpoint.ToString()));
-            fluxnodeEntry.push_back(Pair("alias", zne.getAlias()));
+            fluxnodeEntry.push_back(Pair("alias", entry.getAlias()));
 
             bool fChecked = false;
             if (mempool.mapFluxnodeTxMempool.count(outpoint)) {
@@ -476,7 +476,7 @@ UniValue startfluxnode(const UniValue& params, bool fHelp, string cmdname)
 
             mutTransaction.nVersion = FLUXNODE_TX_VERSION;
 
-            bool result = activeFluxnode.BuildDeterministicStartTx(zne.getPrivKey(), zne.getTxHash(), zne.getOutputIndex(), errorMessage, mutTransaction);
+            bool result = activeFluxnode.BuildDeterministicStartTx(entry.getPrivKey(), entry.getTxHash(), entry.getOutputIndex(), errorMessage, mutTransaction);
 
             fluxnodeEntry.pushKV("transaction_built", result ? "successful" : "failed");
 

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -732,7 +732,7 @@ bool FluxnodeCache::Flush()
      * 2. Add the nodes collateral into the map that tracks all collaterals added at its height
      * 3. Mark the collateral as dirty so it can be databased when the daemon shutdowns.
      */
-    for (auto item : mapStartTxTracker) {
+    for (const auto& item : mapStartTxTracker) {
         g_fluxnodeCache.mapStartTxTracker[item.first] = item.second;
         g_fluxnodeCache.mapStartTxHeights[item.second.nAddedBlockHeight].insert(item.first);
         g_fluxnodeCache.setDirtyOutPoint.insert(item.first);
@@ -744,7 +744,7 @@ bool FluxnodeCache::Flush()
      * 2. Remove the node from the start tracker
      * 3. Mark the collateral as dirty so it can be databased when the daemon shutdowns
      */
-    for (auto item : mapStartTxDOSTracker) {
+    for (const auto& item : mapStartTxDOSTracker) {
         g_fluxnodeCache.mapStartTxDOSTracker[item.first] = item.second;
         g_fluxnodeCache.mapStartTxTracker.erase(item.first);
         g_fluxnodeCache.setDirtyOutPoint.insert(item.first);
@@ -755,7 +755,7 @@ bool FluxnodeCache::Flush()
      * 1. Add the nodes info into the Height tracker for DOS nodes at the height
      * 2. Remove the entire set of nodes from the start height tracker
      */
-    for (auto item : mapStartTxDOSHeights) {
+    for (const auto& item : mapStartTxDOSHeights) {
         g_fluxnodeCache.mapStartTxDOSHeights[item.first] = item.second;
 
         // TODO - Remove when not needed
@@ -769,7 +769,7 @@ bool FluxnodeCache::Flush()
      * 2. Mark the removed nodes as dirty so they can be databased when the node shutdowns
      * 3. Remove all entries from the DOS heights tracker at the height they were added at
      */
-    for (auto item : mapDosExpiredToRemove) {
+    for (const auto& item : mapDosExpiredToRemove) {
         for (const auto& data : item.second) {
             g_fluxnodeCache.mapStartTxDOSTracker.erase(data);
             g_fluxnodeCache.setDirtyOutPoint.insert(data);

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -159,7 +159,7 @@ public:
         SetNull();
     }
 
-    bool IsNull() {
+    bool IsNull() const{
         return nType == FLUXNODE_NO_TYPE;
     }
 
@@ -449,6 +449,8 @@ std::string GetP2SHFluxNodePublicKey(const CTransaction& tx);
 bool GetKeysForP2SHFluxNode(CPubKey& pubKeyRet, CKey& keyRet);
 
 bool IsFluxnodeTransactionsActive();
+
+
 
 
 

--- a/src/zelnode/zelnodeconfig.cpp
+++ b/src/zelnode/zelnodeconfig.cpp
@@ -97,7 +97,7 @@ bool FluxnodeConfig::read(std::string& strErr)
     return true;
 }
 
-bool FluxnodeConfig::FluxnodeEntry::castOutputIndex(int &n)
+bool FluxnodeConfig::FluxnodeEntry::castOutputIndex(int &n) const
 {
     try {
         n = std::stoi(outputIndex);

--- a/src/zelnode/zelnodeconfig.h
+++ b/src/zelnode/zelnodeconfig.h
@@ -60,7 +60,7 @@ public:
             return outputIndex;
         }
 
-        bool castOutputIndex(int& n);
+        bool castOutputIndex(int& n) const;
 
         void setOutputIndex(const std::string& outputIndex)
         {
@@ -107,7 +107,7 @@ public:
     bool read(std::string& strErr);
     void add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
 
-    std::vector <FluxnodeEntry>& getEntries()
+    std::vector <FluxnodeEntry> getEntries()
     {
         return entries;
     }


### PR DESCRIPTION
- For users that are managing lots of nodes in the fluxnode.conf, starting them can cause the daemon to lock up and become unresponsive. 
- For people calling listfluxnodes all the time, there is now a cache that is retained as long as the block height doesn't change

Fixes for this include: 
- Making sure when we loop through vectors of data we are accessing the items by reference(&) instead of copying them into memory. 
- Caching the list of available fluxnodes in memory after the first time we loop through all wallet transactions. Instead of processing through every wallet transaction for each node we want to start. I believe this is the biggest contributor to the daemon locking up as we was LOCK and UNLOCK the wallet critical section. This change will at least free up a lot of locks and hopefully will make the processes a lot smooth and produce less errors.  