### PR TITLE
Remove lock test

### DIFF
--- a/src/zelnode/activezelnode.cpp
+++ b/src/zelnode/activezelnode.cpp
@@ -90,12 +90,6 @@ bool ActiveFluxnode::GetFluxNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey
     }
 
     // Find possible candidates
-    TRY_LOCK(pwalletMain->cs_wallet, fWallet);
-    if (!fWallet) {
-        errorMessage = "Couldn't find Flux Node Vin: Couldn't Lock Wallet";
-        return false;
-    }
-
     vector<std::pair<COutput, CAmount>> possibleCoins = SelectCoinsFluxnode();
     COutput* selectedOutput;
 


### PR DESCRIPTION
Fixes #220 
The wallet is locked when 

`vector<std::pair<COutput, CAmount>> possibleCoins = SelectCoinsFluxnode(); calls

`pwalletMain->AvailableCoins(vCoins, true, NULL, false, false, ALL_FLUXNODE);`

So the functions that are using the wallet already lock the need critical sections. 

