### PR TITLE
[WIP] Start P2SH fluxnodes

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -239,13 +239,18 @@ void CTransaction::UpdateHash() const
 }
 
 CTransaction::CTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0), vin(), vout(), nLockTime(0),
-                               valueBalance(0), vShieldedSpend(), vShieldedOutput(), vJoinSplit(), joinSplitPubKey(), joinSplitSig(), bindingSig(), nType(FLUXNODE_NO_TYPE), collateralOut(), collateralPubkey(), pubKey(), sigTime(0), ip(), sig(), benchmarkTier(0), benchmarkSig(), benchmarkSigTime(0), nUpdateType(0)  { }
+                               valueBalance(0), vShieldedSpend(), vShieldedOutput(), vJoinSplit(), joinSplitPubKey(), joinSplitSig(), bindingSig(), nType(FLUXNODE_NO_TYPE),
+                               collateralOut(), collateralPubkey(), pubKey(), sigTime(0), ip(), sig(), benchmarkTier(0), benchmarkSig(), benchmarkSigTime(0), nUpdateType(0),
+                               nFluxNodeTxVersion(0), P2SHRedeemScript()  { }
 
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
                                                             vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
                                                             valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                                                             vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
-                                                            bindingSig(tx.bindingSig), nType(tx.nType), collateralOut(tx.collateralIn), collateralPubkey(tx.collateralPubkey), pubKey(tx.pubKey), sigTime(tx.sigTime), ip(tx.ip), sig(tx.sig), benchmarkTier(tx.benchmarkTier), benchmarkSig(tx.benchmarkSig), benchmarkSigTime(tx.benchmarkSigTime), nUpdateType(tx.nUpdateType)
+                                                            bindingSig(tx.bindingSig), nType(tx.nType), collateralOut(tx.collateralIn), collateralPubkey(tx.collateralPubkey),
+                                                            pubKey(tx.pubKey), sigTime(tx.sigTime), ip(tx.ip), sig(tx.sig), benchmarkTier(tx.benchmarkTier),
+                                                            benchmarkSig(tx.benchmarkSig), benchmarkSigTime(tx.benchmarkSigTime), nUpdateType(tx.nUpdateType),
+                                                            nFluxNodeTxVersion(tx.nFluxNodeTxVersion), P2SHRedeemScript(tx.P2SHRedeemScript)
 {
     UpdateHash();
 }
@@ -258,7 +263,12 @@ CTransaction::CTransaction(
                               vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
                               valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                               vJoinSplit(tx.vJoinSplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
-                              bindingSig(tx.bindingSig), nType(tx.nType), collateralOut(tx.collateralIn), collateralPubkey(tx.collateralPubkey), pubKey(tx.pubKey), sigTime(tx.sigTime), ip(tx.ip), sig(tx.sig), benchmarkTier(tx.benchmarkTier), benchmarkSig(tx.benchmarkSig), benchmarkSigTime(tx.benchmarkSigTime), nUpdateType(tx.nUpdateType)
+                              bindingSig(tx.bindingSig), nType(tx.nType), collateralOut(tx.collateralIn),
+                              collateralPubkey(tx.collateralPubkey), pubKey(tx.pubKey), sigTime(tx.sigTime),
+                              ip(tx.ip), sig(tx.sig), benchmarkTier(tx.benchmarkTier),
+                              benchmarkSig(tx.benchmarkSig), benchmarkSigTime(tx.benchmarkSigTime),
+                              nUpdateType(tx.nUpdateType), nFluxNodeTxVersion(tx.nFluxNodeTxVersion),
+                              P2SHRedeemScript(tx.P2SHRedeemScript)
 {
     assert(evilDeveloperFlag);
 }
@@ -269,7 +279,11 @@ CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion), fO
                                                        vShieldedSpend(std::move(tx.vShieldedSpend)), vShieldedOutput(std::move(tx.vShieldedOutput)),
                                                        vJoinSplit(std::move(tx.vJoinSplit)),
                                                        joinSplitPubKey(std::move(tx.joinSplitPubKey)), joinSplitSig(std::move(tx.joinSplitSig)),
-                                                       nType(tx.nType), collateralOut(tx.collateralIn), collateralPubkey(tx.collateralPubkey), pubKey(tx.pubKey), sigTime(tx.sigTime), ip(tx.ip), sig(tx.sig), benchmarkTier(tx.benchmarkTier), benchmarkSig(tx.benchmarkSig), benchmarkSigTime(tx.benchmarkSigTime), nUpdateType(tx.nUpdateType)
+                                                       nType(tx.nType), collateralOut(tx.collateralIn), collateralPubkey(tx.collateralPubkey),
+                                                       pubKey(tx.pubKey), sigTime(tx.sigTime), ip(tx.ip),
+                                                       sig(tx.sig), benchmarkTier(tx.benchmarkTier), benchmarkSig(tx.benchmarkSig),
+                                                       benchmarkSigTime(tx.benchmarkSigTime), nUpdateType(tx.nUpdateType), nFluxNodeTxVersion(tx.nFluxNodeTxVersion),
+                                                       P2SHRedeemScript(tx.P2SHRedeemScript)
 {
     UpdateHash();
 }
@@ -303,6 +317,10 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<std::vector<unsigned char>*>(&benchmarkSig) = tx.benchmarkSig;
     *const_cast<uint32_t*>(&benchmarkSigTime) = tx.benchmarkSigTime;
     *const_cast<int8_t*>(&nUpdateType) = tx.nUpdateType;
+
+    // P2SH Nodes
+    *const_cast<uint32_t*>(&nFluxNodeTxVersion) = tx.nFluxNodeTxVersion;
+    *const_cast<CScript*>(&P2SHRedeemScript) = tx.P2SHRedeemScript;
 
 
     return *this;

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -190,6 +190,8 @@ void GetUndoDataForPaidFluxnodes(CFluxnodeTxBlockUndo& fluxnodeTxBlockUndo, Flux
 
 void FluxnodeCache::AddNewStart(const CTransaction& p_transaction, const int p_nHeight, int nTier, const CAmount nCollateral)
 {
+    // TODO - modify the start function to use the version 2 tx after a certain p_nHeight
+
     FluxnodeCacheData data;
     data.nStatus = FLUXNODE_TX_STARTED;
     data.nType = FLUXNODE_START_TX_TYPE;
@@ -787,6 +789,7 @@ bool FluxnodeCache::Flush()
         // Loop through all COutPoints and remove them from the DOS Tracker.
         for (const auto& out : item.second) {
             g_fluxnodeCache.mapStartTxDOSTracker.erase(out);
+            g_fluxnodeCache.setDirtyOutPoint.insert(out);
         }
 
         // Remove all data at the Block Height

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -139,6 +139,10 @@ public:
     std::string ip;
     int8_t nTier;
 
+    // P2SH Nodes
+    uint32_t nFluxNodeTxVersion;
+    CScript P2SHRedeemScript;
+
     int8_t nStatus;
 
     CAmount nCollateral;
@@ -153,6 +157,8 @@ public:
         nTier = 0;
         nStatus =  FLUXNODE_TX_ERROR;
         nCollateral = 0;
+        nFluxNodeTxVersion = 0;
+        P2SHRedeemScript.clear();
     }
 
     FluxnodeCacheData() {
@@ -213,18 +219,51 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(nType);
-        READWRITE(collateralIn);
-        READWRITE(collateralPubkey);
-        READWRITE(pubKey);
-        READWRITE(nAddedBlockHeight);
-        READWRITE(nConfirmedBlockHeight);
-        READWRITE(nLastConfirmedBlockHeight);
-        READWRITE(nLastPaidHeight);
-        READWRITE(ip);
-        READWRITE(nTier);
-        READWRITE(nStatus);
-        if (nType & FLUXNODE_HAS_COLLATERAL) {
-            READWRITE(nCollateral);
+
+        // New nType Version Checker
+        if (nType ^ FLUXNODE_TX_VERSION_2  == 0) {
+            READWRITE(nFluxNodeTxVersion);
+            if (nFluxNodeTxVersion == FLUXNODE_TX_VERSION_2_NORMAL_START) {
+                READWRITE(collateralIn);
+                READWRITE(collateralPubkey);
+                READWRITE(pubKey);
+                READWRITE(nAddedBlockHeight);
+                READWRITE(nConfirmedBlockHeight);
+                READWRITE(nLastConfirmedBlockHeight);
+                READWRITE(nLastPaidHeight);
+                READWRITE(ip);
+                READWRITE(nTier);
+                READWRITE(nStatus);
+                READWRITE(nCollateral);
+            } else if (nFluxNodeTxVersion == FLUXNODE_TX_VERSION_2_P2SH_START) {
+                READWRITE(collateralIn);
+                READWRITE(collateralPubkey);
+                READWRITE(pubKey);
+                READWRITE(nAddedBlockHeight);
+                READWRITE(nConfirmedBlockHeight);
+                READWRITE(nLastConfirmedBlockHeight);
+                READWRITE(nLastPaidHeight);
+                READWRITE(ip);
+                READWRITE(nTier);
+                READWRITE(nStatus);
+                READWRITE(nCollateral);
+                READWRITE(P2SHRedeemScript);
+            }
+        } else {
+            // We must retain backwards compatibility with older transactions
+            READWRITE(collateralIn);
+            READWRITE(collateralPubkey);
+            READWRITE(pubKey);
+            READWRITE(nAddedBlockHeight);
+            READWRITE(nConfirmedBlockHeight);
+            READWRITE(nLastConfirmedBlockHeight);
+            READWRITE(nLastPaidHeight);
+            READWRITE(ip);
+            READWRITE(nTier);
+            READWRITE(nStatus);
+            if (nType & FLUXNODE_HAS_COLLATERAL) {
+                READWRITE(nCollateral);
+            }
         }
     }
 };


### PR DESCRIPTION
c15ff0b2cda42c067ec77e82ce17a1cf0209b6b5 - Modify the main CTransaction functions to include new required parameters. Came up with new Tx Version Flow that we can use to make fluxnode Tx changes easier. Modified how the network and database will be able to process the new type of FluxNode Tx. 

Not yet done: 

- Add forking code so that these new types of transaction go active only after a certain block height. 
- Add Script Process and Signature verification for P2SH addresses.
- Add the ability to start a fluxnode tx with only a single signature from a P2SH redeem script. 
- Modify existing transaction validation process to handle P2SH node transactions. 