### PR TITLE
[Feature] Add ability for users to set a default change address

### DIFF
--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -19,6 +19,7 @@ public:
     //! Ability to send only from a specific address
     CTxDestination fromOnlyDest;
     bool fFromOnlyIsSet;
+    bool fDefaultChangeIsSet;
 
     CCoinControl()
     {
@@ -30,6 +31,7 @@ public:
         destChange = CNoDestination();
         fromOnlyDest = CNoDestination();
         fFromOnlyIsSet = false;
+        fDefaultChangeIsSet = false;
         fAllowOtherInputs = false;
         setSelected.clear();
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -527,6 +527,9 @@ std::string HelpMessage(HelpMessageMode mode)
  #endif
             ));
 #endif
+    strUsage += HelpMessageOpt("-defaultchangeaddressmainnet", _("Default Change address to be used when sendmany rpc call is used (Mainnet Only)"));
+    strUsage += HelpMessageOpt("-defaultchangeaddresstestnet", _("Default Change address to be used when sendmany rpc call is used (Testnet Only)"));
+
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));


### PR DESCRIPTION
Fluxpools have reported that they would like the ability to set a default change address for when the are sending payments to miners. The reason for this feature request is because normal transactions generate a new address to be the change address causing the wallet to grow in size. 

To allow this type of feature fluxd now allows two new parameters to be passed to fluxd when starting the application or they can be placed in the flux.conf.

- **defaultchangeaddressmainnet**= valid_mainnet_address
- **defaultchangeaddresstestnet**= valid_testnet_address

The default change address will be assigned if it was passed to the application in either of the mechanisms above, it is a valid address for the network is belongs to, and it will only work with the following rpc calls

- **sendmany**
- **sendtoaddress**

The rpccall **sendfrom** defaults to sending the change back to the address that it is sending from. So the default change address will not be used when this rpc is used. 

Tests to be completed before merging:

- [x] Set a testnet address into the **defaultchangeaddressmainnet** - Verify that the change address is not set and instead defaults to generating a new change address for the transaction when using **sendmany** and **sendtoaddress**
- [x] Set a mainnet address into the  **defaultchangeaddresstestnet** - Verify that the change address is not set and instead defults to generating a new change address for the transaction when using **sendmany** and **sendtoaddress**
- [x] Set the defaultchange address to a invalid address string - Verify that the change address is not used and instead defaults to generating a new change address for the transaction
- [x] Set a valid address to be the change address - Verify that the address is used as the change address when using **sendmany** and **sendtoaddress**
- [x] Set a valid address to be the change address - Verify that the address isn't used when using **sendfrom**