### PR TITLE
Fix ubuntu upgrade24

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you are building for Ubuntu 20.04 or Ubuntu 22.04 use the following to instal
 
 ```
 sudo apt-get update && sudo apt-get upgrade -y
-sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf2.64 libtool ncurses-dev unzip git python-ispython3 zlib1g-dev wget curl bsdmainutils automake
+sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf2.64 libtool ncurses-dev unzip git zlib1g-dev wget curl bsdmainutils automake
 ```
 
 For other targets or additional information see the Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To setup a FluxNode please follow this [guide](https://medium.com/@mmalik4/flux-
 
 ### Building
 
-If you are building for Ubuntu 20.04 or Ubuntu 22.04 use the following to install the dependencies:
+If you are building for Ubuntu 20.04, Ubuntu 22.04 or Ubuntu 24.04 use the following to install the dependencies:
 
 ```
 sudo apt-get update && sudo apt-get upgrade -y

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoco
 For other targets or additional information see the Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon).
 
 
-If you have the dependencies you can build Flux Daemon from source by running:
+Once you have the dependencies you can build Flux Daemon from source by running:
 
 ```
 ./zcutil/build.sh -j$(nproc)

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ To setup a FluxNode please follow this [guide](https://medium.com/@mmalik4/flux-
 
 ### Building
 
-Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon).
-
 If you are building for Ubuntu 20.04 or Ubuntu 22.04 use the following to install the dependencies:
 
 ```
 sudo apt-get update && sudo apt-get upgrade -y
 sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf2.64 libtool ncurses-dev unzip git python-ispython3 zlib1g-dev wget curl bsdmainutils automake
 ```
+
+For other targets or additional information see the Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon).
+
 
 If you have the dependencies you can build Flux Daemon from source by running:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ To setup a FluxNode please follow this [guide](https://medium.com/@mmalik4/flux-
 
 Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon).
 
+If you are building for Ubuntu 20.04 or Ubuntu 22.04 use the following to install the dependencies:
+
+```
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf2.64 libtool ncurses-dev unzip git python-ispython3 zlib1g-dev wget curl bsdmainutils automake
+```
+
 If you have the dependencies you can build Flux Daemon from source by running:
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sudo apt-get update && sudo apt-get upgrade -y
 sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf2.64 libtool ncurses-dev unzip git zlib1g-dev wget curl bsdmainutils automake
 ```
 
-For other targets or additional information see the Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon).
+For other targets or additional information see the Flux Daemon build and installation guide is [here](https://zel.gitbook.io/zelcurrency/installing-zel-daemon)
 
 
 Once you have the dependencies you can build Flux Daemon from source by running:


### PR DESCRIPTION
Update to use autoconf 2.64 which will not upgrade to the latest autoconf.
There is no guarantee about backwards compatibility with autoconf

This was found when trying to build on a system upgraded from 20.04 to 22.04