### PR TITLE
Stop halving

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1885,6 +1885,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     fFluxnode = GetBoolArg("-zelnode", false);
+    fArcane = getenv("UNMANAGED_FLUXBENCHD") != NULL;
 
     if ((fFluxnode || fluxnodeConfig.getCount() > -1) && fTxIndex == false) {
         return InitError("Enabling Fluxnode support requires turning on transaction indexing."
@@ -1984,7 +1985,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         
     }
 
-    if (fFluxnode) {
+    if (fFluxnode && !fArcane) {
         // Check if the benchmark application is running
         if (!IsFluxBenchdRunning()) {
             StartFluxBenchd();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2477,6 +2477,14 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     if (halvings >= 64)
         return 0;
 
+    // As of June 27th, 2025 we are at 2 halvings
+    // This will be a temp solution while we work on the next
+    // blockchain improvement protocols
+    if (halvings >= 2) {
+        nSubsidy >>= 2;
+        return nSubsidy;
+    }
+
     // Subsidy is cut in half every 655,350 blocks which will occur approximately every 2.5 years.
     nSubsidy >>= halvings;
     return nSubsidy;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1096,9 +1096,8 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
             "getchaintips\n"
             "Return information about all known tips in the block tree,"
             " including the main chain as well as orphaned branches.\n"
-            "getchaintips now accepts 1 parameter. If a parameter is passed in, it will search\n"
-            " the entire chain for chaintips. If no parameter is given, it will search the most recent\n"
-            " 100,000 block heights\n"
+            "\nArguments:\n"
+            "1. blockheight   (numeric, optional, default=0) What block height to start checking at if valid\n"
             "\nResult:\n"
             "[\n"
             "  {\n"
@@ -1128,10 +1127,17 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
     LOCK(cs_main);
 
     int currentHeight = chainActive.Height();
-    int minHeight = std::max(0, currentHeight - 100000);
+    int minHeight = 0;
 
+    int pBlockHeight = 0;
     if (params.size() == 1) {
-        minHeight = 0;
+        pBlockHeight = params[0].get_int();
+
+        if (pBlockHeight < 0 || pBlockHeight > currentHeight) {
+            minHeight = 0;
+        } else {
+            minHeight = std::max(0, pBlockHeight);
+        }
     }
 
     // First, collect only relevant blocks

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -147,7 +147,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_setmigration", 0},
     { "spork", 1},
     { "printsnapshot", 0},
-    { "createp2shstarttx", 3}
+    { "createp2shstarttx", 3},
+    { "getchaintips", 0 }
 };
 
 class CRPCConvertTable

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -103,6 +103,7 @@ using namespace std;
 string strFluxnodeAddr = "";
 string strFluxnodePrivKey = "";
 bool fFluxnode = false;
+bool fArcane = false;
 
 CCriticalSection cs_args;
 map<string, string> mapArgs;

--- a/src/util.h
+++ b/src/util.h
@@ -36,6 +36,7 @@ static const bool DEFAULT_LOGTIMESTAMPS = true;
 
 /** Fluxnode features */
 extern bool fFluxnode;
+extern bool fArcane;
 extern std::string strFluxnodeAddr;
 
 


### PR DESCRIPTION
- Stops halving at current block reward
- Improve getchaintips RPC call
  - Now defaults to searching the last 100,000 blocks.
  - Now accepts a parameter which would force the entire chain search